### PR TITLE
Add GitHub metrics tooling to shared tooling repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+node_modules
+.idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 This repository contains tooling that the MongoDB Developer Docs team 
 uses to help us audit and track code examples across MongoDB's documentation
 corpus.
+
+- `github-metrics`: a Node.js script to get metrics from GitHub and write them to a collection in Atlas

--- a/github-metrics/README.md
+++ b/github-metrics/README.md
@@ -85,7 +85,7 @@ For this project, as a MongoDB org member, you must also auth your PAT with SSO.
 
    > Note: The `.env` file is in the `.gitignore`, so no worries about accidentally committing credentials.
 
-#. **Install the dependencies**
+2. **Install the dependencies**
 
    From the root of the directory, run the following command to install project dependencies:
 
@@ -93,7 +93,7 @@ For this project, as a MongoDB org member, you must also auth your PAT with SSO.
    npm install
    ```
 
-#. **Run the utility**
+3. **Run the utility**
 
    From the root of the directory, run the following command to run the utility:
 

--- a/github-metrics/README.md
+++ b/github-metrics/README.md
@@ -6,8 +6,7 @@ Currently, it contains a PoC for a simple pipeline to pull metrics from GitHub i
 
 Planned future work: 
 
-- Set up a server to pull metrics every 14 days 
-- Add logic to work with pulled metrics once available in the test repo
+- Add logic to work with pulled maintenance metrics once available in the test repo
 - Set up Atlas Charts to visualize the data
 
 ## GitHub Repo Metrics
@@ -22,6 +21,8 @@ for a given repository over a trailing 14 day period:
 - Stars
 - Watchers
 - Forks
+- Top 10 referral sources
+- Top 10 paths/destinations in the repo
 
 The intent is to also get the following maintenance-related stats for a given repository over a trailing 14 day period:
 
@@ -33,8 +34,8 @@ However, at present, GitHub does not have any data cached for the test repo, so 
 This code is in the `get-github-metrics.js` file.
 
 > **Note**: The GitHub API does not provide the option to specify a date range for these metrics. The API _only_ provides
-> this data for the trailing 14 day period, fixed. In the future, we'll want to set up a server to run this job regularly
-> since we cannot specify a date range.
+> this data for the trailing 14 day period, fixed. We'll need to re-run this job regularly, and in the future, we
+> may want to set up a server to run this job since we cannot specify a date range.
 
 ### Write metrics to Atlas
 
@@ -71,37 +72,37 @@ For this project, as a MongoDB org member, you must also auth your PAT with SSO.
 
 #### Steps
 
-##### Create a `.env` file
+1. **Create a `.env` file**
 
-Create a `.env` file that contains the following details:
+   Create a `.env` file that contains the following details:
 
-```
-ATLAS_CONNECTION_STRING="yourConnectionString"
-GITHUB_TOKEN="yourToken"
-```
+   ```
+   ATLAS_CONNECTION_STRING="yourConnectionString"
+   GITHUB_TOKEN="yourToken"
+   ```
 
-Replace the placeholder values with your connection string and GitHub token.
+   Replace the placeholder values with your connection string and GitHub token.
 
-The `.env` file is in the `.gitignore`, so no worries about accidentally committing credentials.
+   > Note: The `.env` file is in the `.gitignore`, so no worries about accidentally committing credentials.
 
-##### Install the dependencies
+#. **Install the dependencies**
 
-From the root of the directory, run the following command to install project dependencies:
+   From the root of the directory, run the following command to install project dependencies:
 
-```
-npm install
-```
+   ```
+   npm install
+   ```
 
-##### Run the utility
+#. **Run the utility**
 
-From the root of the directory, run the following command to run the utility:
+   From the root of the directory, run the following command to run the utility:
 
-```
-node --env-file=.env index.js
-```
+   ```
+   node --env-file=.env index.js
+   ```
 
-You should see output similar to:
+   You should see output similar to:
 
-```
-A document was inserted with the _id: 678197a0ffe1539ff213bd86
-```
+   ```
+   A document was inserted with the _id: 678197a0ffe1539ff213bd86
+   ```

--- a/github-metrics/README.md
+++ b/github-metrics/README.md
@@ -1,4 +1,4 @@
-# Project Metrics Tooling
+# GitHub Metrics Tooling
 
 This directory contains tooling to enable us to track various GitHub project metrics programmatically.
 

--- a/github-metrics/README.md
+++ b/github-metrics/README.md
@@ -1,9 +1,14 @@
 # Project Metrics Tooling
 
-This repo contains tooling to enable us to programmatically keep track of various project metrics.
+This directory contains tooling to enable us to track various GitHub project metrics programmatically.
 
-At the moment, it only contains a PoC for a simple pipeline to get metrics out of GitHub and into MongoDB Atlas. In the
-future, we can move this into the `mongodb` org and add tooling for our various projects.
+Currently, it contains a PoC for a simple pipeline to pull metrics from GitHub into MongoDB Atlas. 
+
+Planned future work: 
+
+- Set up a server to pull metrics every 14 days 
+- Add logic to work with pulled metrics once available in the test repo
+- Set up Atlas Charts to visualize the data
 
 ## GitHub Repo Metrics
 
@@ -55,7 +60,7 @@ Contact a member of the Developer Docs team to be added to this project and get 
 
 **GitHub**:
 
-- A [GitHub Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+- A [GitHub Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) (PAT)
   with `repo` permissions
 
 For this project, as a MongoDB org member, you must also auth your PAT with SSO.

--- a/github-metrics/README.md
+++ b/github-metrics/README.md
@@ -1,0 +1,102 @@
+# Project Metrics Tooling
+
+This repo contains tooling to enable us to programmatically keep track of various project metrics.
+
+At the moment, it only contains a PoC for a simple pipeline to get metrics out of GitHub and into MongoDB Atlas. In the
+future, we can move this into the `mongodb` org and add tooling for our various projects.
+
+## GitHub Repo Metrics
+
+### Get Metrics from GitHub
+
+This is a simple PoC that uses [octokit](https://github.com/octokit/octokit.js) to get the following data out of GitHub
+for a given repository over a trailing 14 day period:
+
+- Views
+- Unique Views
+- Stars
+- Watchers
+- Forks
+
+The intent is to also get the following maintenance-related stats for a given repository over a trailing 14 day period:
+
+- Code frequency
+- Commit count
+
+However, at present, GitHub does not have any data cached for the test repo, so I'll iterate on this in a future version.
+
+This code is in the `get-github-metrics.js` file.
+
+> **Note**: The GitHub API does not provide the option to specify a date range for these metrics. The API _only_ provides
+> this data for the trailing 14 day period, fixed. In the future, we'll want to set up a server to run this job regularly
+> since we cannot specify a date range.
+
+### Write metrics to Atlas
+
+This PoC uses the [MongoDB Node.js Driver](https://www.mongodb.com/docs/drivers/node/current/) to write the data to the
+**Developer Docs** -> **Project Metrics** project in Atlas.
+
+This code is in the `write-to-db.js` file.
+
+In the future, we can set up Charts to visualize this data and share it with stakeholders.
+
+### Run the tool
+
+#### Prerequisites
+
+To run the tool, you need:
+
+**Atlas**:
+
+- An Atlas Database User with write permissions for the **Developer Docs** -> **Project Metrics** project.
+- A valid connection string for the cluster above.
+
+Contact a member of the Developer Docs team to be added to this project and get the connection string.
+
+**GitHub**:
+
+- A [GitHub Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+  with `repo` permissions
+
+For this project, as a MongoDB org member, you must also auth your PAT with SSO.
+
+**System**:
+
+- Node.js/npm installed
+
+#### Steps
+
+##### Create a `.env` file
+
+Create a `.env` file that contains the following details:
+
+```
+ATLAS_CONNECTION_STRING="yourConnectionString"
+GITHUB_TOKEN="yourToken"
+```
+
+Replace the placeholder values with your connection string and GitHub token.
+
+The `.env` file is in the `.gitignore`, so no worries about accidentally committing credentials.
+
+##### Install the dependencies
+
+From the root of the directory, run the following command to install project dependencies:
+
+```
+npm install
+```
+
+##### Run the utility
+
+From the root of the directory, run the following command to run the utility:
+
+```
+node --env-file=.env index.js
+```
+
+You should see output similar to:
+
+```
+A document was inserted with the _id: 678197a0ffe1539ff213bd86
+```

--- a/github-metrics/README.md
+++ b/github-metrics/README.md
@@ -9,9 +9,9 @@ Planned future work:
 - Add logic to work with pulled maintenance metrics once available in the test repo
 - Set up Atlas Charts to visualize the data
 
-## GitHub Repo Metrics
+## GitHub repo metrics
 
-### Get Metrics from GitHub
+### Get metrics from GitHub
 
 This is a simple PoC that uses [octokit](https://github.com/octokit/octokit.js) to get the following data out of GitHub
 for a given repository over a trailing 14 day period:

--- a/github-metrics/get-github-metrics.js
+++ b/github-metrics/get-github-metrics.js
@@ -100,7 +100,7 @@ async function getTopPaths(octokit, owner, repo) {
     return paths;
 }
 
-// Currently there is no data to display, so not sure what form the return data takes. Will add details to work with this data once I can get a return value.
+// Currently there is no data to display, so not sure what form the return data takes. // @todo Add details to work with this data once I can get a return value.
 async function getMaintenanceInfo(octokit, owner, repo) {
     const codeFrequency = await octokit.rest.repos.getCodeFrequencyStats({
         owner: owner,

--- a/github-metrics/get-github-metrics.js
+++ b/github-metrics/get-github-metrics.js
@@ -1,0 +1,123 @@
+import { Octokit } from "octokit";
+
+class ReferrerTraffic {
+    constructor(referrer, count, uniques) {
+        this.referrer = referrer;
+        this.count = count;
+        this.uniques = uniques;
+    }
+}
+
+class TopPaths {
+    constructor(path, count, uniques) {
+        this.path = path;
+        this.count = count;
+        this.uniques = uniques;
+    }
+}
+
+async function getGitHubMetrics(owner, repo) {
+    const apiToken = process.env.GITHUB_TOKEN
+    const octokit = new Octokit({
+        auth: apiToken,
+    });
+    await octokit.rest.users.getAuthenticated();
+    const clones = await getRepoClones(octokit, owner, repo);
+    const pageViews = await getPageViews(octokit, owner, repo);
+    const metricCounts = await getRepoMetricCounts(octokit, owner, repo);
+    const referralSources = await getReferralSources(octokit, owner, repo);
+    const topPaths = await getTopPaths(octokit, owner, repo);
+    return {
+        date: new Date().toISOString(),
+        owner: owner,
+        repo: repo,
+        clones: clones,
+        totalViews: pageViews.viewCount,
+        uniqueViews: pageViews.uniqueViews,
+        stars: metricCounts.stars,
+        forks: metricCounts.forks,
+        watchers: metricCounts.watchers,
+        referralSources: referralSources,
+        topPaths: topPaths,
+    }
+}
+
+async function getRepoClones(octokit, owner, repo) {
+    const clones = await octokit.rest.repos.getClones({
+        owner: owner,
+        repo: repo
+    });
+    return clones.data.count;
+}
+
+async function getPageViews(octokit, owner, repo) {
+    const pageViews = await octokit.rest.repos.getViews({
+        owner: owner,
+        repo: repo
+    });
+    return {
+        viewCount: pageViews.data.count,
+        uniqueViews: pageViews.data.uniques,
+    }
+}
+
+async function getRepoMetricCounts(octokit, owner, repo) {
+    const repoDetails = await octokit.rest.repos.get({
+        owner: owner,
+        repo: repo
+    });
+    const stars = repoDetails.data.stargazers_count;
+    const forks = repoDetails.data.forks_count;
+    const watchers = repoDetails.data.watchers;
+    return {
+        stars: stars,
+        forks: forks,
+        watchers: watchers
+    }
+}
+
+async function getReferralSources(octokit, owner, repo) {
+    const repoDetails = await octokit.rest.repos.getTopReferrers({
+        owner: owner,
+        repo: repo
+    });
+    let referralSources = [];
+    repoDetails.data.map(item => {
+        referralSources.push(new ReferrerTraffic(item.referrer, item.count, item.uniques));
+    });
+    return referralSources;
+}
+
+async function getTopPaths(octokit, owner, repo) {
+    const repoDetails = await octokit.rest.repos.getTopPaths({
+        owner: owner,
+        repo: repo
+    });
+    let paths = [];
+    repoDetails.data.map(item => {
+        paths.push(new TopPaths(item.path, item.count, item.uniques));
+    });
+    return paths;
+}
+
+// Currently there is no data to display, so not sure what form the return data takes. Will add details to work with this data once I can get a return value.
+async function getMaintenanceInfo(octokit, owner, repo) {
+    const codeFrequency = await octokit.rest.repos.getCodeFrequencyStats({
+        owner: owner,
+        repo: repo
+    });
+    const commits = await octokit.rest.repos.getCommitActivityStats({
+        owner: owner,
+        repo: repo
+    });
+    if (codeFrequency.status === 202 || commits.status === 202) {
+        console.log("GitHub returned a 202, which means the requested data is not currently cached. Try again later.")
+    } else {
+        console.log(codeFrequency);
+        console.log(commits);
+    }
+}
+
+export {
+    getGitHubMetrics
+}

--- a/github-metrics/get-github-metrics.js
+++ b/github-metrics/get-github-metrics.js
@@ -100,7 +100,8 @@ async function getTopPaths(octokit, owner, repo) {
     return paths;
 }
 
-// Currently there is no data to display, so not sure what form the return data takes. // @todo Add details to work with this data once I can get a return value.
+// Currently there is no data to display, so not sure what form the return data takes.
+// @todo Add details to work with this data once I can get a return value.
 async function getMaintenanceInfo(octokit, owner, repo) {
     const codeFrequency = await octokit.rest.repos.getCodeFrequencyStats({
         owner: owner,

--- a/github-metrics/index.js
+++ b/github-metrics/index.js
@@ -1,0 +1,13 @@
+import { getGitHubMetrics } from "./get-github-metrics.js";
+import { addMetricsToAtlas } from "./write-to-db.js";
+
+// To change the repo we're tracking, change the owner and/or repo name here.
+// Owner corresponds to the GitHub organization or member who owns the repo
+// Repo corresponds to the name of the repo within the organization or member
+// The URL for this repo is: https://github.com/mongodb/docs-notebooks
+// The URL pattern to figure out owner/repo is: https://github.com/owner/repo
+// The GitHub token used to retrieve the info must have repo admin permissions to access all the endpoints in this code
+const owner = "mongodb";
+const repo = "docs-notebooks";
+const metricsDoc = await getGitHubMetrics(owner, repo);
+await addMetricsToAtlas(metricsDoc);

--- a/github-metrics/index.js
+++ b/github-metrics/index.js
@@ -1,13 +1,12 @@
 import { getGitHubMetrics } from "./get-github-metrics.js";
 import { addMetricsToAtlas } from "./write-to-db.js";
 
-// To change the repo we're tracking, change the owner and/or repo name here.
-// Owner corresponds to the GitHub organization or member who owns the repo
-// Repo corresponds to the name of the repo within the organization or member
-// The URL for this repo is: https://github.com/mongodb/docs-notebooks
-// The URL pattern to figure out owner/repo is: https://github.com/owner/repo
-// The GitHub token used to retrieve the info must have repo admin permissions to access all the endpoints in this code
-const owner = "mongodb";
-const repo = "docs-notebooks";
+/* To change the repo we're tracking metrics for, change the owner and/or repo name here.
+The URL pattern is: `https://github.com/<owner>/<repo>`
+For example, the URL for the `mongodb`-owned `docs-notebooks` repo is: `https://github.com/mongodb/docs-notebooks`
+NOTE: The GitHub token used to retrieve the info from a repo MUST have repo admin permissions to access all the endpoints in this code. */
+
+const owner = "mongodb"; // the GitHub organization or member who owns the repo
+const repo = "docs-notebooks"; // the name of the repo within the organization or member
 const metricsDoc = await getGitHubMetrics(owner, repo);
 await addMetricsToAtlas(metricsDoc);

--- a/github-metrics/package-lock.json
+++ b/github-metrics/package-lock.json
@@ -1,0 +1,591 @@
+{
+  "name": "github-metrics-tooling",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "github-metrics-tooling",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "esm": "^3.2.25",
+        "mongodb": "^6.12.0",
+        "octokit": "^4.1.0"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
+      "integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@octokit/app": {
+      "version": "15.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-15.1.2.tgz",
+      "integrity": "sha512-6aKmKvqnJKoVK+kx0mLlBMKmQYoziPw4Rd/PWr0j65QVQlrDXlu6hGU8fmTXt7tNkf/DsubdIaTT4fkoWzCh5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-app": "^7.1.4",
+        "@octokit/auth-unauthenticated": "^6.1.1",
+        "@octokit/core": "^6.1.3",
+        "@octokit/oauth-app": "^7.1.5",
+        "@octokit/plugin-paginate-rest": "^11.3.6",
+        "@octokit/types": "^13.6.2",
+        "@octokit/webhooks": "^13.4.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-app": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-7.1.4.tgz",
+      "integrity": "sha512-5F+3l/maq9JfWQ4bV28jT2G/K8eu9OJ317yzXPTGe4Kw+lKDhFaS4dQ3Ltmb6xImKxfCQdqDqMXODhc9YLipLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^8.1.2",
+        "@octokit/auth-oauth-user": "^5.1.2",
+        "@octokit/request": "^9.1.4",
+        "@octokit/request-error": "^6.1.6",
+        "@octokit/types": "^13.6.2",
+        "toad-cache": "^3.7.0",
+        "universal-github-app-jwt": "^2.2.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-8.1.2.tgz",
+      "integrity": "sha512-3woNZgq5/S6RS+9ZTq+JdymxVr7E0s4EYxF20ugQvgX3pomdPUL5r/XdTY9wALoBM2eHVy4ettr5fKpatyTyHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^7.1.2",
+        "@octokit/auth-oauth-user": "^5.1.2",
+        "@octokit/request": "^9.1.4",
+        "@octokit/types": "^13.6.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-7.1.2.tgz",
+      "integrity": "sha512-gTOIzDeV36OhVfxCl69FmvJix7tJIiU6dlxuzLVAzle7fYfO8UDyddr9B+o4CFQVaMBLMGZ9ak2CWMYcGeZnPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-methods": "^5.1.3",
+        "@octokit/request": "^9.1.4",
+        "@octokit/types": "^13.6.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-5.1.2.tgz",
+      "integrity": "sha512-PgVDDPJgZYb3qSEXK4moksA23tfn68zwSAsQKZ1uH6IV9IaNEYx35OXXI80STQaLYnmEE86AgU0tC1YkM4WjsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^7.1.2",
+        "@octokit/oauth-methods": "^5.1.2",
+        "@octokit/request": "^9.1.4",
+        "@octokit/types": "^13.6.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
+      "integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-unauthenticated": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-6.1.1.tgz",
+      "integrity": "sha512-bGXqdN6RhSFHvpPq46SL8sN+F3odQ6oMNLWc875IgoqcC3qus+fOL2th6Tkl94wvdSTy8/OeHzWy/lZebmnhog==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request-error": "^6.1.6",
+        "@octokit/types": "^13.6.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.3.tgz",
+      "integrity": "sha512-z+j7DixNnfpdToYsOutStDgeRzJSMnbj8T1C/oQjB6Aa+kRfNjs/Fn7W6c8bmlt6mfy3FkgeKBRnDjxQow5dow==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^5.0.0",
+        "@octokit/graphql": "^8.1.2",
+        "@octokit/request": "^9.1.4",
+        "@octokit/request-error": "^6.1.6",
+        "@octokit/types": "^13.6.2",
+        "before-after-hook": "^3.0.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.2.tgz",
+      "integrity": "sha512-XybpFv9Ms4hX5OCHMZqyODYqGTZ3H6K6Vva+M9LR7ib/xr1y1ZnlChYv9H680y77Vd/i/k+thXApeRASBQkzhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.6.2",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.2.tgz",
+      "integrity": "sha512-bdlj/CJVjpaz06NBpfHhp4kGJaRZfz7AzC+6EwUImRtrwIw8dIgJ63Xg0OzV9pRn3rIzrt5c2sa++BL0JJ8GLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^9.1.4",
+        "@octokit/types": "^13.6.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/oauth-app": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-7.1.5.tgz",
+      "integrity": "sha512-/Y2MiwWDlGUK4blKKfjJiwjzu/FzwKTTTfTZAAQ0QbdBIDEGJPWhOFH6muSN86zaa4tNheB4YS3oWIR2e4ydzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^8.1.2",
+        "@octokit/auth-oauth-user": "^5.1.2",
+        "@octokit/auth-unauthenticated": "^6.1.1",
+        "@octokit/core": "^6.1.3",
+        "@octokit/oauth-authorization-url": "^7.1.1",
+        "@octokit/oauth-methods": "^5.1.3",
+        "@types/aws-lambda": "^8.10.83",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/oauth-authorization-url": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-7.1.1.tgz",
+      "integrity": "sha512-ooXV8GBSabSWyhLUowlMIVd9l1s2nsOGQdlP2SQ4LnkEsGXzeCvbSbCPdZThXhEFzleGPwbapT0Sb+YhXRyjCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/oauth-methods": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-5.1.3.tgz",
+      "integrity": "sha512-M+bDBi5H8FnH0xhCTg0m9hvcnppdDnxUqbZyOkxlLblKpLAR+eT2nbDPvJDp0eLrvJWA1I8OX0KHf/sBMQARRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^7.0.0",
+        "@octokit/request": "^9.1.4",
+        "@octokit/request-error": "^6.1.6",
+        "@octokit/types": "^13.6.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/openapi-webhooks-types": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-8.5.1.tgz",
+      "integrity": "sha512-i3h1b5zpGSB39ffBbYdSGuAd0NhBAwPyA3QV3LYi/lx4lsbZiu7u2UHgXVUR6EpvOI8REOuVh1DZTRfHoJDvuQ==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-graphql": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-5.2.4.tgz",
+      "integrity": "sha512-pLZES1jWaOynXKHOqdnwZ5ULeVR6tVVCMm+AUbp0htdcyXDU95WbkYdU4R2ej1wKj5Tu94Mee2Ne0PjPO9cCyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.0.tgz",
+      "integrity": "sha512-ttpGck5AYWkwMkMazNCZMqxKqIq1fJBNxBfsFwwfyYKTf914jKkLF0POMS3YkPBwp5g1c2Y4L79gDz01GhSr1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.7.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.0.tgz",
+      "integrity": "sha512-LUm44shlmkp/6VC+qQgHl3W5vzUP99ZM54zH6BuqkJK4DqfFLhegANd+fM4YRLapTvPm4049iG7F3haANKMYvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.7.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-7.1.3.tgz",
+      "integrity": "sha512-8nKOXvYWnzv89gSyIvgFHmCBAxfQAOPRlkacUHL9r5oWtp5Whxl8Skb2n3ACZd+X6cYijD6uvmrQuPH/UCL5zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request-error": "^6.1.6",
+        "@octokit/types": "^13.6.2",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-9.4.0.tgz",
+      "integrity": "sha512-IOlXxXhZA4Z3m0EEYtrrACkuHiArHLZ3CvqWwOez/pURNqRuwfoFlTPbN5Muf28pzFuztxPyiUiNwz8KctdZaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.7.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^6.1.3"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.4.tgz",
+      "integrity": "sha512-tMbOwGm6wDII6vygP3wUVqFTw3Aoo0FnVQyhihh8vVq12uO3P+vQZeo2CKMpWtPSogpACD0yyZAlVlQnjW71DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^10.0.0",
+        "@octokit/request-error": "^6.0.1",
+        "@octokit/types": "^13.6.2",
+        "fast-content-type-parse": "^2.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.6.tgz",
+      "integrity": "sha512-pqnVKYo/at0NuOjinrgcQYpEbv4snvP3bKMRqHaD9kIsk9u1LCpb2smHZi8/qJfgeNqLo5hNW4Z7FezNdEo0xg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.6.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.7.0.tgz",
+      "integrity": "sha512-BXfRP+3P3IN6fd4uF3SniaHKOO4UXWBfkdR3vA8mIvaoO/wLjGN5qivUtW0QRitBHHMcfC41SLhNVYIZZE+wkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^23.0.1"
+      }
+    },
+    "node_modules/@octokit/webhooks": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-13.4.2.tgz",
+      "integrity": "sha512-fakbgkCScapQXPxyqx2jZs/Y3jGlyezwUp7ATL7oLAGJ0+SqBKWKstoKZpiQ+REeHutKpYjY9UtxdLSurwl2Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-webhooks-types": "8.5.1",
+        "@octokit/request-error": "^6.1.6",
+        "@octokit/webhooks-methods": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/webhooks-methods": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-5.1.0.tgz",
+      "integrity": "sha512-yFZa3UH11VIxYnnoOYCVoJ3q4ChuSOk2IVBBQ0O3xtKX4x9bmKb/1t+Mxixv2iUhzMdOl1qeWJqEhouXXzB3rQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.147",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.147.tgz",
+      "integrity": "sha512-nD0Z9fNIZcxYX5Mai2CTmFD7wX7UldCkW2ezCF8D1T5hdiLsnTWDGRpfRYntU6VjTdLQjOvyszru7I1c1oCQew==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "license": "MIT"
+    },
+    "node_modules/bson": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.1.tgz",
+      "integrity": "sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
+    },
+    "node_modules/mongodb": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.12.0.tgz",
+      "integrity": "sha512-RM7AHlvYfS7jv7+BXund/kR64DryVI+cHbVAy9P61fnb1RcWZqOW1/Wj2YhqMCx+MuYhqTRGv7AwHBzmsCKBfA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.1",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
+      "integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^13.0.0"
+      }
+    },
+    "node_modules/octokit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/octokit/-/octokit-4.1.0.tgz",
+      "integrity": "sha512-/UrQAOSvkc+lUUWKNzy4ByAgYU9KpFzZQt8DnC962YmQuDiZb1SNJ90YukCCK5aMzKqqCA+z1kkAlmzYvdYKag==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/app": "^15.1.2",
+        "@octokit/core": "^6.1.3",
+        "@octokit/oauth-app": "^7.1.4",
+        "@octokit/plugin-paginate-graphql": "^5.2.4",
+        "@octokit/plugin-paginate-rest": "^11.4.0",
+        "@octokit/plugin-rest-endpoint-methods": "^13.3.0",
+        "@octokit/plugin-retry": "^7.1.3",
+        "@octokit/plugin-throttling": "^9.4.0",
+        "@octokit/request-error": "^6.1.6",
+        "@octokit/types": "^13.7.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/universal-github-app-jwt": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.0.tgz",
+      "integrity": "sha512-G5o6f95b5BggDGuUfKDApKaCgNYy2x7OdHY0zSMF081O0EJobw+1130VONhrA7ezGSV2FNOGyM+KQpQZAr9bIQ==",
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+      "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
+      "license": "ISC"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/github-metrics/package.json
+++ b/github-metrics/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "github-metrics-tooling",
+  "version": "1.0.0",
+  "main": "index.js",
+  "module": "get-github-metrics.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "type": "module",
+  "dependencies": {
+    "esm": "^3.2.25",
+    "mongodb": "^6.12.0",
+    "octokit": "^4.1.0"
+  }
+}

--- a/github-metrics/write-to-db.js
+++ b/github-metrics/write-to-db.js
@@ -5,7 +5,6 @@ async function addMetricsToAtlas(metricsDoc) {
     const client = new MongoClient(uri);
     try {
         await client.connect();
-
         const database = client.db("github_metrics");
         const coll = database.collection(metricsDoc.owner + "_" + metricsDoc.repo);
         const result = await coll.insertOne(metricsDoc);

--- a/github-metrics/write-to-db.js
+++ b/github-metrics/write-to-db.js
@@ -6,8 +6,6 @@ async function addMetricsToAtlas(metricsDoc) {
     try {
         await client.connect();
 
-        // Currently, the only metrics we're tracking are coming from GitHub, so the DB is hard-coded here
-        // Propose we name the collection for the GitHub repo (or maybe 'owner_repo' to avoid namespace issues?)
         const database = client.db("github_metrics");
         const coll = database.collection(metricsDoc.owner + "_" + metricsDoc.repo);
         const result = await coll.insertOne(metricsDoc);

--- a/github-metrics/write-to-db.js
+++ b/github-metrics/write-to-db.js
@@ -1,0 +1,22 @@
+import { MongoClient } from 'mongodb';
+
+async function addMetricsToAtlas(metricsDoc) {
+    const uri =  process.env.ATLAS_CONNECTION_STRING;
+    const client = new MongoClient(uri);
+    try {
+        await client.connect();
+
+        // Currently, the only metrics we're tracking are coming from GitHub, so the DB is hard-coded here
+        // Propose we name the collection for the GitHub repo (or maybe 'owner_repo' to avoid namespace issues?)
+        const database = client.db("github_metrics");
+        const coll = database.collection(metricsDoc.owner + "_" + metricsDoc.repo);
+        const result = await coll.insertOne(metricsDoc);
+        console.log(`A document was inserted with the _id: ${result.insertedId}`);
+    } finally {
+        await client.close();
+    }
+}
+
+export {
+    addMetricsToAtlas,
+}


### PR DESCRIPTION
This little command line tool pulls data from GitHub for the specified repo, and writes it to a database and collection in Atlas.

In the future, as we are tracking metrics for more repos, we can add code to iterate through a list of repos we're passing and write the data to Atlas.