### PR TITLE
Add collection counts to the new applied usage example printout

### DIFF
--- a/audit/dodec/src/PerformAggregation.go
+++ b/audit/dodec/src/PerformAggregation.go
@@ -19,7 +19,12 @@ func PerformAggregation(db *mongo.Database, ctx context.Context) {
 	//nestedTwoLevelMap := make(map[string]map[string]map[string]int)
 	//pageIdChangesCountMap := make(map[string][]types.PageIdChangedCounts)
 	//pageIdsWithNodeLangCountMismatch := make(map[string][]string)
-	pageIdWithNewAppliedUsageExampleCountMap := make(map[string][]types.PageIdNewAppliedUsageExamples)
+	newAppliedUsageExampleCounter := types.NewAppliedUsageExampleCounter{
+		ProductCounts:      make(map[string]int),
+		SubProductCounts:   make(map[string]int),
+		AggregateCount:     0,
+		PagesInCollections: make(map[string][]types.PageIdNewAppliedUsageExamples),
+	}
 
 	// If you just need to get data for a single collection, perform the aggregation using the collection name
 	//simpleMap = aggregations.GetLanguageCounts(db, "pymongo", simpleMap, ctx)
@@ -49,7 +54,7 @@ func PerformAggregation(db *mongo.Database, ctx context.Context) {
 		//pageIdChangesCountMap = aggregations.GetDocsIdsWithRecentActivity(db, collectionName, pageIdChangesCountMap, ctx)
 		//pageIdsWithNodeLangCountMismatch = aggregations.GetPagesWithNodeLangCountMismatch(db, collectionName, pageIdsWithNodeLangCountMismatch, ctx)
 		//pageIdsWithNodeLangCountMismatch = aggregations.FindDocsMissingProduct(db, collectionName, pageIdsWithNodeLangCountMismatch, ctx)
-		pageIdWithNewAppliedUsageExampleCountMap = aggregations.FindNewAppliedUsageExamples(db, collectionName, pageIdWithNewAppliedUsageExampleCountMap, ctx)
+		newAppliedUsageExampleCounter = aggregations.FindNewAppliedUsageExamples(db, collectionName, newAppliedUsageExampleCounter, ctx)
 	}
 
 	//simpleTableLabel := "Collection"
@@ -71,5 +76,5 @@ func PerformAggregation(db *mongo.Database, ctx context.Context) {
 	//utils.PrintCodeLengthMapToConsole(codeLengthMap)
 	//utils.PrintPageIdChangesCountMap(pageIdChangesCountMap)
 	//utils.PrintPageIdsWithNodeLangCountMismatch(pageIdsWithNodeLangCountMismatch)
-	utils.PrintPageIdNewAppliedUsageExampleCounts(pageIdWithNewAppliedUsageExampleCountMap)
+	utils.PrintPageIdNewAppliedUsageExampleCounts(newAppliedUsageExampleCounter)
 }

--- a/audit/dodec/src/aggregations/FindNewAppliedUsageExamples.go
+++ b/audit/dodec/src/aggregations/FindNewAppliedUsageExamples.go
@@ -4,13 +4,18 @@ import (
 	"common"
 	"context"
 	"dodec/types"
+	"dodec/utils"
 	"fmt"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"time"
 )
 
-func FindNewAppliedUsageExamples(db *mongo.Database, collectionName string, pageIdsWithNewUsageExamples map[string][]types.PageIdNewAppliedUsageExamples, ctx context.Context) map[string][]types.PageIdNewAppliedUsageExamples {
+// FindNewAppliedUsageExamples looks for docs pages in Atlas that have had a new usage example added within the last week,
+// where the usage example character count is over 300 characters. We use this is a proxy for determining "new applied
+// usage example". We get a count of new usage examples matching this criteria, return the count and the page_id, and
+// track the product and sub-product in the types.NewAppliedUsageExampleCounter
+func FindNewAppliedUsageExamples(db *mongo.Database, collectionName string, appliedUsageExampleCounter types.NewAppliedUsageExampleCounter, ctx context.Context) types.NewAppliedUsageExampleCounter {
 	// Calculate last week's date range
 	now := time.Now()
 	oneWeekAgo := now.AddDate(0, 0, -7)
@@ -41,36 +46,65 @@ func FindNewAppliedUsageExamples(db *mongo.Database, collectionName string, page
 			}},
 		}}},
 
-		// Group documents by _id and collect matching nodes
+		// First group by Product and SubProduct
 		bson.D{{"$group", bson.D{
-			{"_id", "$_id"},
-			{"matchingNodes", bson.D{{"$push", "$nodes"}}},
+			{"_id", bson.D{
+				{"product", "$product"},
+				{"subProduct", bson.D{{"$ifNull", bson.A{"$sub_product", "None"}}}},
+			}},
+			{"nodesPerProduct", bson.D{{"$push", bson.D{
+				{"_id", "$_id"},     // Preserve original document _id
+				{"nodes", "$nodes"}, // Collect nodes
+			}}}},
+		}}},
+		// Unwind after the first group to regroup by original _id
+		bson.D{{"$unwind", bson.D{{"path", "$nodesPerProduct"}}}},
+		// Regroup by original document _id within each Product and SubProduct
+		bson.D{{"$group", bson.D{
+			{"_id", bson.D{
+				{"product", "$_id.product"},
+				{"subProduct", "$_id.subProduct"},
+				{"documentId", "$nodesPerProduct._id"},
+			}},
+			{"matchingNodes", bson.D{{"$push", "$nodesPerProduct.nodes"}}},
 			{"count", bson.D{{"$sum", 1}}},
 		}}},
+		// Optionally sort by count in descending order
+		bson.D{{"$sort", bson.D{{"count", -1}}}},
 	}
 	// Execute the aggregation
 	collection := db.Collection(collectionName)
 	cursor, err := collection.Aggregate(ctx, pipeline)
 	if err != nil {
 		println(fmt.Errorf("failed to execute aggregate query: %v", err))
-		return pageIdsWithNewUsageExamples
+		return appliedUsageExampleCounter
 	}
 	defer cursor.Close(ctx)
 	collectionPagesWithNewAppliedUsageExamples := make([]types.PageIdNewAppliedUsageExamples, 0)
 	for cursor.Next(ctx) {
 		var result types.PageIdNewAppliedUsageExamples
-		if err := cursor.Decode(&result); err != nil {
+		if err = cursor.Decode(&result); err != nil {
 			println(fmt.Errorf("failed to decode result document: %v", err))
-			return pageIdsWithNewUsageExamples
+			return appliedUsageExampleCounter
 		}
-		collectionPagesWithNewAppliedUsageExamples = append(collectionPagesWithNewAppliedUsageExamples, result)
+		appliedUsageExampleCounter.AggregateCount += result.Count
+		appliedUsageExampleCounter.ProductCounts[result.ID.Product] += result.Count
+
+		// The docs org would like to see a breakdown of focus areas. For the purpose of reporting this result, I'm arbitrarily
+		// assigning some of the key focus areas as "sub-product" if a page ID contains a substring related to these focus
+		// areas. That makes it easy to report on these things as sub-products even if they're not officially sub-products.
+		resultAdjustedForFocusAreas := utils.GetFocusAreaAsSubProduct(result)
+		if resultAdjustedForFocusAreas.ID.SubProduct != "None" {
+			appliedUsageExampleCounter.SubProductCounts[resultAdjustedForFocusAreas.ID.SubProduct] += resultAdjustedForFocusAreas.Count
+		}
+		collectionPagesWithNewAppliedUsageExamples = append(collectionPagesWithNewAppliedUsageExamples, resultAdjustedForFocusAreas)
 	}
-	if err := cursor.Err(); err != nil {
+	if err = cursor.Err(); err != nil {
 		println(fmt.Errorf("cursor encountered an error: %v", err))
-		return pageIdsWithNewUsageExamples
+		return appliedUsageExampleCounter
 	}
 	if collectionPagesWithNewAppliedUsageExamples != nil && len(collectionPagesWithNewAppliedUsageExamples) > 0 {
-		pageIdsWithNewUsageExamples[collectionName] = collectionPagesWithNewAppliedUsageExamples
+		appliedUsageExampleCounter.PagesInCollections[collectionName] = collectionPagesWithNewAppliedUsageExamples
 	}
-	return pageIdsWithNewUsageExamples
+	return appliedUsageExampleCounter
 }

--- a/audit/dodec/src/types/NewAppliedUsageExampleCounter.go
+++ b/audit/dodec/src/types/NewAppliedUsageExampleCounter.go
@@ -1,0 +1,10 @@
+package types
+
+// NewAppliedUsageExampleCounter aggregates counts and page IDs for pages with new usage examples across collections.
+// Used by the aggregations.FindNewAppliedUsageExamples function.
+type NewAppliedUsageExampleCounter struct {
+	ProductCounts      map[string]int
+	SubProductCounts   map[string]int
+	AggregateCount     int
+	PagesInCollections map[string][]PageIdNewAppliedUsageExamples
+}

--- a/audit/dodec/src/types/PageIdNewAppliedUsageExamples.go
+++ b/audit/dodec/src/types/PageIdNewAppliedUsageExamples.go
@@ -3,7 +3,14 @@ package types
 import "common"
 
 type PageIdNewAppliedUsageExamples struct {
-	ID                      string            `bson:"_id"`
-	NewAppliedUsageExamples []common.CodeNode `bson:"new_applied_usage_examples"`
-	Count                   int               `bson:"count"`
+	ID                      ProductSubProductDocumentID `bson:"_id"`
+	NewAppliedUsageExamples []common.CodeNode           `bson:"new_applied_usage_examples"`
+	Count                   int                         `bson:"count"`
+}
+
+// ProductSubProductDocumentID represents the structure for the grouped _id field.
+type ProductSubProductDocumentID struct {
+	Product    string `bson:"product"`
+	SubProduct string `bson:"subProduct"`
+	DocumentID string `bson:"documentId"`
 }

--- a/audit/dodec/src/updates/CopyDBForTesting.go
+++ b/audit/dodec/src/updates/CopyDBForTesting.go
@@ -9,7 +9,7 @@ import (
 
 func CopyDBForTesting(client *mongo.Client, ctx context.Context) {
 	sourceDb := client.Database("code_metrics")
-	targetDb := client.Database("backup_code_metrics")
+	targetDb := client.Database("backup_code_metrics_Mar_26")
 	// List all collections in the source database
 	collectionNames, err := sourceDb.ListCollectionNames(ctx, bson.D{})
 	if err != nil {

--- a/audit/dodec/src/utils/GetFocusAreaAsSubProduct.go
+++ b/audit/dodec/src/utils/GetFocusAreaAsSubProduct.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"dodec/types"
+	"strings"
+)
+
+// GetFocusAreaAsSubProduct takes info about pages that have new applied usage examples, parses the document `_id` string
+// to determine if it contains a substring related to one of the focus areas the docs org cares about, and returns a
+// version of the types.PageIdNewAppliedUsageExamples struct with the focus area as the sub-product, even if it's not
+// "really" a sub-product. This does not modify the document in the database - only gives us a field to tally results
+// after we pull data from Atlas.
+func GetFocusAreaAsSubProduct(newAppliedUsageExampleResult types.PageIdNewAppliedUsageExamples) types.PageIdNewAppliedUsageExamples {
+	maybeModifiedResult := newAppliedUsageExampleResult
+	if strings.Contains(newAppliedUsageExampleResult.ID.DocumentID, "vector-search") {
+		maybeModifiedResult.ID.SubProduct = "Vector Search"
+	} else if strings.Contains(newAppliedUsageExampleResult.ID.DocumentID, "atlas-search") {
+		maybeModifiedResult.ID.SubProduct = "Atlas Search"
+	} else if strings.Contains(newAppliedUsageExampleResult.ID.DocumentID, "time-series") || strings.Contains(newAppliedUsageExampleResult.ID.DocumentID, "timeseries") {
+		maybeModifiedResult.ID.SubProduct = "Time Series"
+	}
+	return maybeModifiedResult
+}

--- a/audit/dodec/src/utils/PrintPageIdNewAppliedUsageExampleCounts.go
+++ b/audit/dodec/src/utils/PrintPageIdNewAppliedUsageExampleCounts.go
@@ -11,6 +11,7 @@ func PrintPageIdNewAppliedUsageExampleCounts(mapToPrint map[string][]types.PageI
 	columnWidths := []int{70, 15}
 	aggregateCount := 0
 	for collectionName, pagesToPrintInCollection := range mapToPrint {
+		collectionCount := 0
 		fmt.Printf("\nNew Applied Usage Example Counts by Page in Collection %s\n", collectionName)
 		printSeparator(columnWidths...)
 		printRow(columnWidths, columnNames...)
@@ -20,8 +21,10 @@ func PrintPageIdNewAppliedUsageExampleCounts(mapToPrint map[string][]types.PageI
 		for _, page := range pagesToPrintInCollection {
 			printRow(columnWidths, page.ID, page.Count)
 			aggregateCount += page.Count
+			collectionCount += page.Count
 		}
 		printSeparator(columnWidths...)
+		fmt.Printf("\nTotal new applied usage example counts in %s: %d\n", collectionName, collectionCount)
 	}
 	fmt.Printf("\nTotal New Applied Usage Example Counts in Last Week: %d\n", aggregateCount)
 }

--- a/audit/dodec/src/utils/PrintPageIdNewAppliedUsageExampleCounts.go
+++ b/audit/dodec/src/utils/PrintPageIdNewAppliedUsageExampleCounts.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 )
 
-func PrintPageIdNewAppliedUsageExampleCounts(mapToPrint map[string][]types.PageIdNewAppliedUsageExamples) {
-	columnNames := []interface{}{"Page ID", "Count"}
+// PrintPageIdNewAppliedUsageExampleCounts prints a nicely-formatted series of tables with counts of new applied usage
+// examples broken down in various ways. Each collection prints as its own table, which has a list of page IDs and counts
+// for pages that have new usage examples. This makes it easy to validate the data if we want to perform manual QA. After
+// the individual collection tables, we print tables breaking down the counts by sub-product and product.
+func PrintPageIdNewAppliedUsageExampleCounts(appliedUsageExampleCounter types.NewAppliedUsageExampleCounter) {
+	columnNames := []interface{}{"Product", "Sub Product", "Page ID", "Count"}
 	// Print a separate table for each top-level element
-	columnWidths := []int{70, 15}
-	aggregateCount := 0
-	for collectionName, pagesToPrintInCollection := range mapToPrint {
+	columnWidths := []int{30, 30, 70, 15}
+	for collectionName, pagesToPrintInCollection := range appliedUsageExampleCounter.PagesInCollections {
 		collectionCount := 0
 		fmt.Printf("\nNew Applied Usage Example Counts by Page in Collection %s\n", collectionName)
 		printSeparator(columnWidths...)
@@ -19,12 +22,23 @@ func PrintPageIdNewAppliedUsageExampleCounts(mapToPrint map[string][]types.PageI
 		// This type also stores the code nodes directly - do we want to print any details about the specific nodes that
 		// match our conditions?
 		for _, page := range pagesToPrintInCollection {
-			printRow(columnWidths, page.ID, page.Count)
-			aggregateCount += page.Count
+			printRow(columnWidths, page.ID.Product, page.ID.SubProduct, page.ID.DocumentID, page.Count)
 			collectionCount += page.Count
 		}
 		printSeparator(columnWidths...)
 		fmt.Printf("\nTotal new applied usage example counts in %s: %d\n", collectionName, collectionCount)
 	}
-	fmt.Printf("\nTotal New Applied Usage Example Counts in Last Week: %d\n", aggregateCount)
+	fmt.Printf("\nTotal New Applied Usage Example Counts in Last Week: %d\n", appliedUsageExampleCounter.AggregateCount)
+
+	// This prints a table showing counts of new applied usage examples broken down by sub-product. To simplify reporting
+	// up the docs chain, the function that performs the aggregation, aggregations.FindNewAppliedUsageExamples, assigns
+	// an arbitrary sub-product related to the Page ID for key focus areas. This print function does not distinguish
+	// between "real" sub-products and sub-product focus areas.
+	PrintSimpleCountDataToConsole(appliedUsageExampleCounter.SubProductCounts, "SubProduct", []interface{}{"SubProduct", "Count"}, []int{20, 15})
+
+	// This prints a table showing counts of new applied usage examples broken down by product. Every docs page has a
+	// Product, and some but not all docs pages have a Sub-Product. The Sub-Product counts are a subset of Product counts.
+	// For example, Vector Search sub-product code example counts are *also* reported separately in the Atlas product
+	// counts - i.e. 46 Atlas code examples would *include* 43 Vector Search sub-product counts.
+	PrintSimpleCountDataToConsole(appliedUsageExampleCounter.ProductCounts, "Product", []interface{}{"Product", "Count"}, []int{40, 15})
 }


### PR DESCRIPTION
Tiny tweaks to the audit reporting to add a count of new applied usage examples per-collection when we're printing out the results. Also, changing the name of the backup DB - I'm thinking we make a dated backup before running the Great Docs Code Devourer, and then delete the old dated backup, so we have a "good" copy of the data we can revert to in case anything goes wonky with the job.