### PR TITLE
(DOCSP-48635): Support getting metrics for multiple repos

### DIFF
--- a/github-metrics/README.md
+++ b/github-metrics/README.md
@@ -37,6 +37,17 @@ This code is in the `get-github-metrics.js` file.
 > this data for the trailing 14 day period, fixed. We'll need to re-run this job regularly, and in the future, we
 > may want to set up a server to run this job since we cannot specify a date range.
 
+### Change repos to track
+
+This project uses `RepoDetails` declared in the `index.js` file to track the owner and repo name for a given project
+whose metrics we want to track.
+
+Declare as many `RepoDetails` as you need, and add them to the `repos` array in ln 19 of the `index.js` file. The code
+handles tracking and writing to Atlas for multiple repos.
+
+Inserting a new repo automatically creates a new corresponding collection in Atlas. You will need to manually create
+Charts to correspond to the new collection.
+
 ### Write metrics to Atlas
 
 This PoC uses the [MongoDB Node.js Driver](https://www.mongodb.com/docs/drivers/node/current/) to write the data to the
@@ -61,8 +72,7 @@ Contact a member of the Developer Docs team to be added to this project and get 
 
 **GitHub**:
 
-- A [GitHub Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) (PAT)
-  with `repo` permissions
+- A [GitHub Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) (PAT) with `repo` permissions
 
 For this project, as a MongoDB org member, you must also auth your PAT with SSO.
 
@@ -104,5 +114,5 @@ For this project, as a MongoDB org member, you must also auth your PAT with SSO.
    You should see output similar to:
 
    ```
-   A document was inserted with the _id: 678197a0ffe1539ff213bd86
+   A document was inserted into mongodb_docs-notebooks with the _id: 678197a0ffe1539ff213bd86
    ```

--- a/github-metrics/get-github-metrics.js
+++ b/github-metrics/get-github-metrics.js
@@ -16,30 +16,39 @@ class TopPaths {
     }
 }
 
+class MetricsDoc {
+    constructor({owner, repo, clones, pageViews, metricCounts, referralSources, topPaths}) {
+        this.date = new Date().toISOString();
+        this.owner = owner;
+        this.repo = repo;
+        this.clones = clones;
+        this.viewCount = pageViews.viewCount;
+        this.uniqueViews = pageViews.uniqueViews;
+        this.stars = metricCounts.stars;
+        this.forks = metricCounts.forks;
+        this.watchers = metricCounts.watchers;
+        this.referralSources = referralSources;
+        this.topPaths = topPaths;
+    }
+}
+
 async function getGitHubMetrics(owner, repo) {
     const apiToken = process.env.GITHUB_TOKEN
     const octokit = new Octokit({
         auth: apiToken,
     });
     await octokit.rest.users.getAuthenticated();
-    const clones = await getRepoClones(octokit, owner, repo);
-    const pageViews = await getPageViews(octokit, owner, repo);
-    const metricCounts = await getRepoMetricCounts(octokit, owner, repo);
-    const referralSources = await getReferralSources(octokit, owner, repo);
-    const topPaths = await getTopPaths(octokit, owner, repo);
-    return {
-        date: new Date().toISOString(),
+
+    const metricsData = {
         owner: owner,
         repo: repo,
-        clones: clones,
-        totalViews: pageViews.viewCount,
-        uniqueViews: pageViews.uniqueViews,
-        stars: metricCounts.stars,
-        forks: metricCounts.forks,
-        watchers: metricCounts.watchers,
-        referralSources: referralSources,
-        topPaths: topPaths,
+        clones: await getRepoClones(octokit, owner, repo),
+        pageViews: await getPageViews(octokit, owner, repo),
+        metricCounts: await getRepoMetricCounts(octokit, owner, repo),
+        referralSources: await getReferralSources(octokit, owner, repo),
+        topPaths: await getTopPaths(octokit, owner, repo),
     }
+    return new MetricsDoc(metricsData);
 }
 
 async function getRepoClones(octokit, owner, repo) {

--- a/github-metrics/index.js
+++ b/github-metrics/index.js
@@ -1,9 +1,11 @@
 import { getGitHubMetrics } from "./get-github-metrics.js";
 import { addMetricsToAtlas } from "./write-to-db.js";
 
-/* To change the repos we're tracking metrics for, change the owner and/or repo name here.
-The URL pattern is: `https://github.com/<owner>/<repo>`
-For example, the URL for the `mongodb`-owned `docs-notebooks` repo is: `https://github.com/mongodb/docs-notebooks`
+/* To change which repos to track metrics for, update the `repos` array before running the utility. 
+To track metrics for a new repo, set the owner and name first. 
+You can get the owner and name from the repo URL: `https://github.com/<owner>/<repo>`
+For example, to add `https://github.com/mongodb/docs-notebooks`, set `mongodb` as the 
+owner and `docs-notebooks` as the repo name.
 NOTE: The GitHub token used to retrieve the info from a repo MUST have repo admin permissions to access all the endpoints in this code. */
 
 class RepoDetails {

--- a/github-metrics/index.js
+++ b/github-metrics/index.js
@@ -1,12 +1,28 @@
 import { getGitHubMetrics } from "./get-github-metrics.js";
 import { addMetricsToAtlas } from "./write-to-db.js";
 
-/* To change the repo we're tracking metrics for, change the owner and/or repo name here.
+/* To change the repos we're tracking metrics for, change the owner and/or repo name here.
 The URL pattern is: `https://github.com/<owner>/<repo>`
 For example, the URL for the `mongodb`-owned `docs-notebooks` repo is: `https://github.com/mongodb/docs-notebooks`
 NOTE: The GitHub token used to retrieve the info from a repo MUST have repo admin permissions to access all the endpoints in this code. */
 
-const owner = "mongodb"; // the GitHub organization or member who owns the repo
-const repo = "docs-notebooks"; // the name of the repo within the organization or member
-const metricsDoc = await getGitHubMetrics(owner, repo);
-await addMetricsToAtlas(metricsDoc);
+class RepoDetails {
+    constructor(owner, repo) {
+        this.owner = owner; // the GitHub organization or member who owns the repo
+        this.repo = repo; // the name of the repo within the organization or member
+    }
+}
+
+const docsNotebooksRepo = new RepoDetails("mongodb", "docs-notebooks");
+const atlasArchitectureGoSdkRepo = new RepoDetails("mongodb", "atlas-architecture-go-sdk");
+
+const repos = [docsNotebooksRepo, atlasArchitectureGoSdkRepo];
+
+const metricsDocs = [];
+
+for (const repo of repos) {
+    const metricsDoc = await getGitHubMetrics(repo.owner, repo.repo);
+    metricsDocs.push(metricsDoc);
+}
+
+await addMetricsToAtlas(metricsDocs);

--- a/github-metrics/write-to-db.js
+++ b/github-metrics/write-to-db.js
@@ -1,14 +1,19 @@
 import { MongoClient } from 'mongodb';
+import {getGitHubMetrics} from "./get-github-metrics.js";
 
-async function addMetricsToAtlas(metricsDoc) {
+async function addMetricsToAtlas(metricsDocs) {
     const uri =  process.env.ATLAS_CONNECTION_STRING;
     const client = new MongoClient(uri);
     try {
         await client.connect();
         const database = client.db("github_metrics");
-        const coll = database.collection(metricsDoc.owner + "_" + metricsDoc.repo);
-        const result = await coll.insertOne(metricsDoc);
-        console.log(`A document was inserted with the _id: ${result.insertedId}`);
+
+        for (const doc of metricsDocs) {
+            const collName = doc.owner + "_" + doc.repo;
+            const coll = database.collection(collName);
+            const result = await coll.insertOne(doc);
+            console.log(`A document was inserted into ${collName} with the _id: ${result.insertedId}`);
+        }
     } finally {
         await client.close();
     }


### PR DESCRIPTION
This PR adds support for getting metrics for multiple repos, and adds tracking for the `atlas-architecture-go-sdk` repo.