### PR TITLE
(DOCSP-49542): Add retry logic to DB query to handle transient errors

### DIFF
--- a/audit/gdcd/db/GetAtlasPageData.go
+++ b/audit/gdcd/db/GetAtlasPageData.go
@@ -52,9 +52,12 @@ func GetAtlasPageData(collectionName string, docId string) *common.DocsPage {
 		}
 
 		if errors.Is(err, mongo.ErrNoDocuments) {
+			// If we return nil here, the app will just make a new page and that's fine
 			return nil
 		}
 
+		// We have seen transient connection errors in the log. For that type of error, try again to retrieve the page
+		// before giving up and creating a new one.
 		if isRetryableError(err, retryableErrorPrefix) {
 			log.Printf("Attempt %d: transient error occurred, retrying: %v", attempts+1, err)
 			time.Sleep(retryDelay)


### PR DESCRIPTION
GDCD sometimes encounters the following error when attempting to retrieve existing documents from DODEC:

```
Error: can't find a matching document for page reference|collations, connection() error occurred during connection handshake: dial tcp: lookup ac-dakfcwt-shard-00-02.h6fulge.mongodb.net: no such host
```

When this error occurs, GDCD does not successfully retrieve the page, and therefore cannot update it based on incoming data from the Snooty Data API. This PR adds retry logic when this error occurs.