### PR TITLE
(DOCSP-49542): Part 2 - Revisit Page Delete Logic

### DIFF
--- a/audit/gdcd/HandleDeletedPages.go
+++ b/audit/gdcd/HandleDeletedPages.go
@@ -6,8 +6,8 @@ import (
 	"gdcd/utils"
 )
 
-// HandleDeletedIncomingPages checks whether a page that has the `"deleted":true` flag when it comes in from the Snooty Data API
-// has a corresponding page in Atlas. If it does, we delete it.
+// HandleDeletedIncomingPages checks whether a page showing as deleted in the Snooty Data API has a corresponding page
+// in Atlas. If it does, we delete it.
 func HandleDeletedIncomingPages(collectionName string, deletedPage types.PageWrapper, report types.ProjectReport) types.ProjectReport {
 	maybeAtlasId := utils.ConvertSnootyPageIdToAtlasPageId(deletedPage.Data.PageID)
 	maybeAtlasDocument := db.GetAtlasPageData(collectionName, maybeAtlasId)

--- a/audit/gdcd/README.md
+++ b/audit/gdcd/README.md
@@ -71,7 +71,7 @@ To perform operations with this project, you need:
 - Ollama installed. Refer to the [Ollama](https://ollama.com/) website for
   installation details.
 - The Ollama [qwen2.5-coder](https://ollama.com/library/qwen2.5-coder) model installed.
-- - A `.env` file for the appropriate environment with details outlined below.
+- A `.env` file for the appropriate environment with details outlined below.
 
 #### Ollama
 

--- a/audit/gdcd/db/GetAtlasPageData.go
+++ b/audit/gdcd/db/GetAtlasPageData.go
@@ -59,7 +59,7 @@ func GetAtlasPageData(collectionName string, docId string) *common.DocsPage {
 		// We have seen transient connection errors in the log. For that type of error, try again to retrieve the page
 		// before giving up and creating a new one.
 		if isRetryableError(err, retryableErrorPrefix) {
-			log.Printf("Attempt %d: transient error occurred, retrying: %v", attempts+1, err)
+			log.Printf("Attempt %d to get page '%s': transient error occurred, retrying. Error: %v", attempts+1, docId, err)
 			time.Sleep(retryDelay)
 			continue
 		} else {

--- a/audit/gdcd/db/HandleMissingPageIds.go
+++ b/audit/gdcd/db/HandleMissingPageIds.go
@@ -14,6 +14,9 @@ func HandleMissingPageIds(collectionName string, incomingPageIds map[string]bool
 	}
 	// Compare the pages that are currently in Atlas with pages coming in from the Snooty Data API. If the page exists
 	// in Atlas but isn't coming in from the Snooty Data API, grab the ID so we can remove the page in Atlas.
+	// TODO: There may be a logic issue here. When we could not retrieve the page ID from the DB; the page was getting
+	//  deleted. That suggests some logic is backward here, but I can't see a logic issue. Revisit if this still appears
+	//  to be a problem now that the DB retrieval func has retry logic. (And/or add testing for this!)
 	var pageIdsWithNoMatchingSnootyPage []string
 	for _, existingId := range existingPageIds {
 		if incomingPageIds[existingId] {

--- a/audit/gdcd/db/HandleMissingPageIds.go
+++ b/audit/gdcd/db/HandleMissingPageIds.go
@@ -8,38 +8,43 @@ import (
 func HandleMissingPageIds(collectionName string, incomingPageIds map[string]bool, report types.ProjectReport) types.ProjectReport {
 	// Get a slice of all the page IDs for pages that are currently in Atlas
 	existingPageIds := GetAtlasPageIDs(collectionName)
-	var missingPageIds []string
-	if existingPageIds != nil {
-		// Compare the pages that are currently in Atlas with pages coming in from the Snooty Data API. If the page exists
-		// in Atlas but isn't coming in from the Snooty Data API, grab the ID so we can remove the page in Atlas.
-		for _, existingId := range existingPageIds {
-			if !incomingPageIds[existingId] {
-				missingPageIds = append(missingPageIds, existingId)
-			}
-		}
+	// If we don't get any page IDs from Atlas, just return the unmodified report
+	if existingPageIds == nil {
+		return report
 	}
-	for _, missingPageId := range missingPageIds {
+	// Compare the pages that are currently in Atlas with pages coming in from the Snooty Data API. If the page exists
+	// in Atlas but isn't coming in from the Snooty Data API, grab the ID so we can remove the page in Atlas.
+	var pageIdsWithNoMatchingSnootyPage []string
+	for _, existingId := range existingPageIds {
+		if incomingPageIds[existingId] {
+			// If the page ID in Atlas matches an incoming page ID from Snooty matches, skip the rest of the loop
+			continue
+		}
+		// If an existing ID in Atlas does not match any of the pages coming in from Snooty, add the ID to a list of pages we should delete
+		pageIdsWithNoMatchingSnootyPage = append(pageIdsWithNoMatchingSnootyPage, existingId)
+	}
+	for _, pageIdToDelete := range pageIdsWithNoMatchingSnootyPage {
 		// We want to report details for the page we're about to delete, so we need to pull up the page to get the details
-		existingPage := GetAtlasPageData(collectionName, missingPageId)
+		existingPage := GetAtlasPageData(collectionName, pageIdToDelete)
 		codeNodeCount := existingPage.CodeNodesTotal
 		literalIncludeCount := existingPage.LiteralIncludesTotal
 		ioCodeBlockCount := existingPage.IoCodeBlocksTotal
-		pageRemoved := RemovePageFromAtlas(collectionName, missingPageId)
+		pageRemoved := RemovePageFromAtlas(collectionName, pageIdToDelete)
 		if pageRemoved {
 			report.Counter.RemovedPagesCount += 1
-			report = utils.ReportChanges(types.PageRemoved, report, missingPageId)
+			report = utils.ReportChanges(types.PageRemoved, report, pageIdToDelete)
 			if codeNodeCount > 0 {
-				report = utils.ReportChanges(types.CodeExampleRemoved, report, missingPageId, codeNodeCount)
+				report = utils.ReportChanges(types.CodeExampleRemoved, report, pageIdToDelete, codeNodeCount)
 				report.Counter.RemovedCodeNodesCount += codeNodeCount
 			}
 			if literalIncludeCount > 0 {
-				report = utils.ReportChanges(types.LiteralIncludeCountChange, report, missingPageId, literalIncludeCount, 0)
+				report = utils.ReportChanges(types.LiteralIncludeCountChange, report, pageIdToDelete, literalIncludeCount, 0)
 			}
 			if ioCodeBlockCount > 0 {
-				report = utils.ReportChanges(types.IoCodeBlockCountChange, report, missingPageId, ioCodeBlockCount, 0)
+				report = utils.ReportChanges(types.IoCodeBlockCountChange, report, pageIdToDelete, ioCodeBlockCount, 0)
 			}
 		} else {
-			report = utils.ReportIssues(types.PageNotRemovedIssue, report, missingPageId)
+			report = utils.ReportIssues(types.PageNotRemovedIssue, report, pageIdToDelete)
 		}
 	}
 	return report


### PR DESCRIPTION
Related to #17 , there appeared from the log output to be a page delete logic issue when we were unable to retrieve the page data from the DB. Failing to retrieve the page subsequently resulted in the page being deleted from the DB. In investigating here, I've added some comments and changed some of the logic to be clearer, but this doesn't actually change the implementation. There is probably still a bug here I can't spot and don't have time to track down right now with impending OOO. 

Have captured details as a TODO, and we can keep an eye out for this or similar scenarios in future log output and add tests to validate this logic as a future unit of work.