### PR TITLE
(DOCSP-49543): GDCD: Fix page count issue bug

### DIFF
--- a/audit/gdcd/CheckDocsForUpdates.go
+++ b/audit/gdcd/CheckDocsForUpdates.go
@@ -57,8 +57,8 @@ func CheckDocsForUpdates(docsPages []types.PageWrapper, project types.DocsProjec
 
 	// Get the existing "summaries" document from the DB, and update it.
 	var summaryDoc common.CollectionReport
-	expectedPageCountFromIncomingPages := incomingPageCount - incomingDeletedPageCount
-	summaryDoc, report = HandleCollectionSummariesDocument(project, report, expectedPageCountFromIncomingPages)
+	report.Counter.TotalCurrentPageCount = incomingPageCount - incomingDeletedPageCount
+	summaryDoc, report = HandleCollectionSummariesDocument(project, report)
 
 	// Output the project report to the log
 	LogReportForProject(project.ProjectName, report)

--- a/audit/gdcd/compare-code-examples/CompareExistingIncomingCodeExampleSlices.go
+++ b/audit/gdcd/compare-code-examples/CompareExistingIncomingCodeExampleSlices.go
@@ -11,10 +11,10 @@ import (
 )
 
 // CompareExistingIncomingCodeExampleSlices takes []common.CodeNode, which represents the existing code example nodes from
-// Atlas, and []types.ASTNode, which represents incoming code examples from the Snooty Data API. It also takes a types.ProjectCounts
-// to track various project counts. This function compares the existing code examples with the incoming code examples
+// Atlas, and []types.ASTNode, which represents incoming code examples from the Snooty Data API. It also takes a types.ProjectReport
+// to track various project changes and counts. This function compares the existing code examples with the incoming code examples
 // to find unchanged, updated, new, and removed nodes. It appends these nodes into an updated []common.CodeNode slice,
-// which it returns to the call site for making updates to Atlas. It also returns the updated types.ProjectCounts.
+// which it returns to the call site for making updates to Atlas. It also returns the updated types.ProjectReport.
 func CompareExistingIncomingCodeExampleSlices(existingNodes []common.CodeNode, existingRemovedNodes []common.CodeNode, incomingNodes []types.ASTNode, report types.ProjectReport, pageId string, llm *ollama.LLM, ctx context.Context, isDriversProject bool) ([]common.CodeNode, types.ProjectReport) {
 	var updatedPageNodes []types.ASTNode
 	var newPageNodes []types.ASTNode


### PR DESCRIPTION
There was an issue with the way I was tracking page counts for a project that was causing this and similar errors:

```
Page count issue: Project atlas-cli: expected current pages from summing changes is 954, got 953
```

I was also recording the incorrect page count in the summaries document, which compounded the error in subsequent tooling runs.

I've simplified some of the logic around the counters here, revisiting how and where I was setting those counts and reducing places where I am unnecessarily duplicating logic or passing around extra counters. This _appears_ to have resolved the issue? 🤞 

Related to this PR, I will manually adjust the page counts in the existing collections so future tooling runs should not hit this issue due to incorrectly set current page values.