### PR TITLE
DODEC: Add a function to consolidate collections for Ask Cal

### DIFF
--- a/audit/common/CALDocsPage.go
+++ b/audit/common/CALDocsPage.go
@@ -1,0 +1,25 @@
+package common
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+type CalDocsPage struct {
+	ID                   bson.ObjectID  `bson:"_id"`              // ObjectID instead of string
+	CodeNodesTotal       int            `bson:"code_nodes_total"` // Keep other fields same as `DocsPage`
+	DateAdded            time.Time      `bson:"date_added"`
+	DateLastUpdated      time.Time      `bson:"date_last_updated"`
+	IoCodeBlocksTotal    int            `bson:"io_code_blocks_total"`
+	Languages            LanguagesArray `bson:"languages"`
+	LiteralIncludesTotal int            `bson:"literal_includes_total"`
+	Nodes                *[]CodeNode    `bson:"nodes"`
+	PageURL              string         `bson:"page_url"`
+	ProjectName          string         `bson:"project_name"`
+	Product              string         `bson:"product"`
+	SubProduct           string         `bson:"sub_product,omitempty"`
+	Keywords             []string       `bson:"keywords,omitempty"`
+	DateRemoved          time.Time      `bson:"date_removed,omitempty"`
+	IsRemoved            bool           `bson:"is_removed,omitempty"`
+}

--- a/audit/dodec/src/updates/ConsolidateCollections.go
+++ b/audit/dodec/src/updates/ConsolidateCollections.go
@@ -1,0 +1,88 @@
+package updates
+
+import (
+	"common"
+	"context"
+	"fmt"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"log"
+)
+
+func ConsolidateCollections(client *mongo.Client, ctx context.Context) {
+	sourceDb := client.Database("code_metrics")
+	targetDbName := "ask_cal"
+	targetDb := client.Database(targetDbName)
+	targetCollName := "consolidated_examples"
+	targetColl := targetDb.Collection(targetCollName)
+	// List all collections in the source database
+	collectionNames, err := sourceDb.ListCollectionNames(ctx, bson.D{})
+	if err != nil {
+		log.Fatalf("Error listing collections: %v", err)
+	}
+	// Iterate over each collection
+	for _, collName := range collectionNames {
+		sourceColl := sourceDb.Collection(collName)
+		// Fetch all documents from the source collection
+		cursor, err := sourceColl.Find(ctx, bson.D{})
+		if err != nil {
+			log.Fatalf("Error finding documents in collection %s: %v", collName, err)
+		}
+		defer func(cursor *mongo.Cursor, ctx context.Context) {
+			err := cursor.Close(ctx)
+			if err != nil {
+				log.Fatalf("Error closing cursor: %v", err)
+			}
+		}(cursor, ctx)
+		var updatedDocuments []common.CalDocsPage
+		for cursor.Next(ctx) {
+			var doc bson.M
+			if err = cursor.Decode(&doc); err != nil {
+				log.Fatalf("Error decoding document in collection %s: %v", collName, err)
+			}
+			idValue, ok := doc["_id"].(string)
+			if ok {
+				if idValue == "summaries" {
+					continue // Skip documents where '_id' is "summaries"
+				} else {
+					// Deserialize into DocsPage
+					var docsPage common.DocsPage
+					if err := cursor.Decode(&docsPage); err != nil {
+						log.Fatalf("Error decoding document into DocsPage: %v", err)
+					}
+					newID := bson.NewObjectID() // Generate a new unique ObjectID
+					// Convert the DocsPage into a modified version of the page with an ObjectID identifier and the origin collection name
+					updatedDoc := common.CalDocsPage{
+						ID:                   newID,
+						CodeNodesTotal:       docsPage.CodeNodesTotal,
+						DateAdded:            docsPage.DateAdded,
+						DateLastUpdated:      docsPage.DateLastUpdated,
+						IoCodeBlocksTotal:    docsPage.IoCodeBlocksTotal,
+						Languages:            docsPage.Languages,
+						LiteralIncludesTotal: docsPage.LiteralIncludesTotal,
+						Nodes:                docsPage.Nodes,
+						PageURL:              docsPage.PageURL,
+						ProjectName:          docsPage.ProjectName,
+						Product:              docsPage.Product,
+						SubProduct:           docsPage.SubProduct,
+						Keywords:             docsPage.Keywords,
+						DateRemoved:          docsPage.DateRemoved,
+						IsRemoved:            docsPage.IsRemoved,
+					}
+					updatedDocuments = append(updatedDocuments, updatedDoc)
+				}
+			} else {
+				fmt.Println("Field '_id' does not exist or is not a string in the document")
+				continue
+			}
+		}
+		if len(updatedDocuments) > 0 {
+			_, err = targetColl.InsertMany(ctx, updatedDocuments)
+			if err != nil {
+				log.Fatalf("Error inserting documents into target DB %s, collection %s: %v", targetDbName, targetCollName, err)
+			}
+			log.Printf("Copied %d documents from %s to collection %s", len(updatedDocuments), collName, targetCollName)
+		}
+	}
+	log.Println("All collections copied successfully")
+}


### PR DESCRIPTION
For Atlas Search reasons, we want all of the code examples in a single collection to use in Ask Cal.

This func:
- Retrieves all `DocsPage` documents from the `code_metrics` database
- Converts them to a `CalDocsPage` where the ID field is an ObjectId (unique) vs. the non-unique string fields used in the `code_metrics` db
- Writes them to a new `consolidated_examples` collection in an `ask_cal` database