### PR TITLE
Minor Ask Cal collection copy logic tweaks

### DIFF
--- a/audit/common/CALDocsPage.go
+++ b/audit/common/CALDocsPage.go
@@ -13,6 +13,7 @@ type CalDocsPage struct {
 	DateLastUpdated      time.Time      `bson:"date_last_updated"`
 	IoCodeBlocksTotal    int            `bson:"io_code_blocks_total"`
 	Languages            LanguagesArray `bson:"languages"`
+	LanguagesFacet       []string       `bson:"languages_facet,omitempty"`
 	LiteralIncludesTotal int            `bson:"literal_includes_total"`
 	Nodes                *[]CodeNode    `bson:"nodes"`
 	PageURL              string         `bson:"page_url"`


### PR DESCRIPTION
Few tweaks to the Ask Cal collection copy logic:

- Only copy pages that have live code examples
- Only copy code examples that are currently live (i.e. `is_removed` is not true)
- Copy the code example languages to a top-level field in the document (`languages_facet`) - Atlas Search can only facet on top-level fields