### PR TITLE
Add a Netlify Function for the request example functionality

### DIFF
--- a/audit/ask-cal/netlify/functions/request-example/go.mod
+++ b/audit/ask-cal/netlify/functions/request-example/go.mod
@@ -1,0 +1,5 @@
+module request-example
+
+go 1.23.1
+
+require github.com/aws/aws-lambda-go v1.48.0 // indirect

--- a/audit/ask-cal/netlify/functions/request-example/go.sum
+++ b/audit/ask-cal/netlify/functions/request-example/go.sum
@@ -1,0 +1,2 @@
+github.com/aws/aws-lambda-go v1.48.0 h1:1aZUYsrJu0yo5fC4z+Rba1KhNImXcJcvHu763BxoyIo=
+github.com/aws/aws-lambda-go v1.48.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=

--- a/audit/ask-cal/netlify/functions/request-example/request-example.go
+++ b/audit/ask-cal/netlify/functions/request-example/request-example.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"net/http"
+	"os"
+)
+
+type RequestBody struct {
+	Description string `json:"Description"`
+}
+
+func handler(request events.APIGatewayProxyRequest) (*events.APIGatewayProxyResponse, error) {
+	var body RequestBody
+	err := json.Unmarshal([]byte(request.Body), &body)
+	if err != nil {
+		return &events.APIGatewayProxyResponse{
+			StatusCode:      422,
+			Headers:         map[string]string{"Content-Type": "text/plain"},
+			Body:            "Invalid input",
+			IsBase64Encoded: false,
+		}, err
+	}
+
+	url := os.Getenv("CODE_EXAMPLE_REQUEST_WEB_HOOK")
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer([]byte(request.Body)))
+	if err != nil {
+		fmt.Println("Error creating request:", err)
+	}
+	// Set request headers
+	req.Header.Set("Content-Type", "application/json")
+
+	// Use the default HTTP client to send the request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Println("Error sending request:", err)
+	}
+	defer resp.Body.Close() // Ensure the response body is closed
+
+	if resp.StatusCode == http.StatusOK {
+		return &events.APIGatewayProxyResponse{
+			StatusCode:      200,
+			Headers:         map[string]string{"Content-Type": "application/json"},
+			Body:            "{\"success\": true\"}",
+			IsBase64Encoded: false,
+		}, nil
+	} else {
+		return &events.APIGatewayProxyResponse{
+			StatusCode:      resp.StatusCode,
+			Headers:         map[string]string{"Content-Type": "text/plain"},
+			Body:            "There was a problem requesting this code example; please contact the Dev Docs team directly",
+			IsBase64Encoded: false,
+		}, nil
+	}
+}
+
+func main() {
+	// Make the handler available for Remote Procedure Call
+	lambda.Start(handler)
+}


### PR DESCRIPTION
This PR adds a `request-example` function we can call to create a Jira ticket requesting a new code example.

Make a POST request to the `request-example` function/endpoint with a body in the following form:

```json
{
	"Description": "TEST: Trying out the Jira webhook from a Netlify function we can use in the website"
}
```

When I add sanitizing for the user feedback comments, I'll also add sanitizing for this function at the same time.