### PR TITLE
DOCSP-50274: Improve handling for errors returned by llms

### DIFF
--- a/audit/gdcd/add-code-examples/CategorizeDriverLanguageSnippet.go
+++ b/audit/gdcd/add-code-examples/CategorizeDriverLanguageSnippet.go
@@ -4,14 +4,12 @@ import (
 	"common"
 	"context"
 	"fmt"
-	"log"
-
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/ollama"
 	"github.com/tmc/langchaingo/prompts"
 )
 
-func CategorizeDriverLanguageSnippet(contents string, llm *ollama.LLM, ctx context.Context) string {
+func CategorizeDriverLanguageSnippet(contents string, llm *ollama.LLM, ctx context.Context) (string, error) {
 	// To tweak the prompt for accuracy, edit this question
 	const questionTemplate = `I need to sort code examples into one of these categories:
 		%s
@@ -37,11 +35,11 @@ func CategorizeDriverLanguageSnippet(contents string, llm *ollama.LLM, ctx conte
 		"question": question,
 	})
 	if err != nil {
-		log.Fatalf("failed to create a prompt from the template: %q\n, %q\n, %q\n, %q\n", template, contents, question, err)
+		return "", fmt.Errorf("failed to create a prompt from the template: %w", err)
 	}
 	completion, err := llms.GenerateFromSinglePrompt(ctx, llm, prompt)
 	if err != nil {
-		log.Fatalf("failed to generate a response from the given prompt: %q", prompt)
+		return "", fmt.Errorf("failed to generate a response from the CategorizeDriverLanguageSnippet prompt (is Ollama running locally?): %w", err)
 	}
-	return completion
+	return completion, nil
 }

--- a/audit/gdcd/add-code-examples/CategorizeDriverLanguageSnippet_test.go
+++ b/audit/gdcd/add-code-examples/CategorizeDriverLanguageSnippet_test.go
@@ -31,7 +31,7 @@ func TestCategorizeDriverLanguageSnippet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CategorizeDriverLanguageSnippet(tt.args.contents, tt.args.llm, tt.args.ctx); got != tt.want {
+			if got, _ := CategorizeDriverLanguageSnippet(tt.args.contents, tt.args.llm, tt.args.ctx); got != tt.want {
 				t.Errorf("CategorizeDriverLanguageSnippet() = got %v, want %v", got, tt.want)
 			}
 		})

--- a/audit/gdcd/add-code-examples/CategorizeJsonLikeSnippet.go
+++ b/audit/gdcd/add-code-examples/CategorizeJsonLikeSnippet.go
@@ -4,14 +4,12 @@ import (
 	"common"
 	"context"
 	"fmt"
-	"log"
-
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/ollama"
 	"github.com/tmc/langchaingo/prompts"
 )
 
-func CategorizeJsonLikeSnippet(contents string, llm *ollama.LLM, ctx context.Context) string {
+func CategorizeJsonLikeSnippet(contents string, llm *ollama.LLM, ctx context.Context) (string, error) {
 	// To tweak the prompt for accuracy, edit this question
 	const questionTemplate = `I need to sort code examples into one of these categories:
 	%s
@@ -37,11 +35,11 @@ func CategorizeJsonLikeSnippet(contents string, llm *ollama.LLM, ctx context.Con
 		"question": question,
 	})
 	if err != nil {
-		log.Fatalf("failed to create a prompt from the template: %q\n, %q\n, %q\n, %q\n", template, contents, question, err)
+		return "", fmt.Errorf("failed to create a prompt from the template: %q\n, %q\n, %q\n, %q\n", template, contents, question, err)
 	}
 	completion, err := llms.GenerateFromSinglePrompt(ctx, llm, prompt)
 	if err != nil {
-		log.Fatalf("failed to generate a response from the given prompt: %q", prompt)
+		return "", fmt.Errorf("failed to generate a response from the CategorizeJsonLikeSnippet prompt (is Ollama running locally?): %w", err)
 	}
-	return completion
+	return completion, nil
 }

--- a/audit/gdcd/add-code-examples/CategorizeShellSnippet.go
+++ b/audit/gdcd/add-code-examples/CategorizeShellSnippet.go
@@ -4,14 +4,12 @@ import (
 	"common"
 	"context"
 	"fmt"
-	"log"
-
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/ollama"
 	"github.com/tmc/langchaingo/prompts"
 )
 
-func CategorizeShellSnippet(contents string, llm *ollama.LLM, ctx context.Context) string {
+func CategorizeShellSnippet(contents string, llm *ollama.LLM, ctx context.Context) (string, error) {
 	// To tweak the prompt for accuracy, edit this question
 	const questionTemplate = `I need to sort code examples into one of these categories:
 	%s
@@ -45,11 +43,11 @@ func CategorizeShellSnippet(contents string, llm *ollama.LLM, ctx context.Contex
 		"question": question,
 	})
 	if err != nil {
-		log.Fatalf("failed to create a prompt from the template: %q\n, %q\n, %q\n, %q\n", template, contents, question, err)
+		return "", fmt.Errorf("failed to create a prompt from the template: %q\n, %q\n, %q\n, %q\n", template, contents, question, err)
 	}
 	completion, err := llms.GenerateFromSinglePrompt(ctx, llm, prompt)
 	if err != nil {
-		log.Fatalf("failed to generate a response from the given prompt: %q", prompt)
+		return "", fmt.Errorf("failed to generate a response from the CategorizeShellSnippet prompt (is Ollama running locally?): %w", err)
 	}
-	return completion
+	return completion, nil
 }

--- a/audit/gdcd/add-code-examples/CategorizeTextSnippet.go
+++ b/audit/gdcd/add-code-examples/CategorizeTextSnippet.go
@@ -4,14 +4,12 @@ import (
 	"common"
 	"context"
 	"fmt"
-	"log"
-
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/ollama"
 	"github.com/tmc/langchaingo/prompts"
 )
 
-func CategorizeTextSnippet(contents string, llm *ollama.LLM, ctx context.Context) string {
+func CategorizeTextSnippet(contents string, llm *ollama.LLM, ctx context.Context) (string, error) {
 	// To tweak the prompt for accuracy, edit this question
 	const questionTemplate = `I need to sort code examples into one of these categories:
 	%s
@@ -49,11 +47,11 @@ func CategorizeTextSnippet(contents string, llm *ollama.LLM, ctx context.Context
 		"question": question,
 	})
 	if err != nil {
-		log.Fatalf("failed to create a prompt from the template: %q\n, %q\n, %q\n, %q\n", template, contents, question, err)
+		return "", fmt.Errorf("failed to create a prompt from the template: %q\n, %q\n, %q\n, %q\n", template, contents, question, err)
 	}
 	completion, err := llms.GenerateFromSinglePrompt(ctx, llm, prompt)
 	if err != nil {
-		log.Fatalf("failed to generate a response from the given prompt: %q", prompt)
+		return "", fmt.Errorf("failed to generate a response from the CategorizeTextSnippet prompt (is Ollama running locally?): %w", err)
 	}
-	return completion
+	return completion, nil
 }

--- a/audit/gdcd/add-code-examples/GetCategory.go
+++ b/audit/gdcd/add-code-examples/GetCategory.go
@@ -4,12 +4,15 @@ import (
 	"common"
 	"context"
 	"gdcd/add-code-examples/utils"
+	"log"
 
 	"github.com/tmc/langchaingo/llms/ollama"
 )
 
 func GetCategory(contents string, lang string, llm *ollama.LLM, ctx context.Context, isDriverProject bool) (string, bool) {
 	var category string
+	var err error
+
 	validCategories := []string{common.ExampleReturnObject, common.ExampleConfigurationObject, common.NonMongoCommand, common.SyntaxExample, common.UsageExample}
 
 	/* If the start characters of the code example match a pattern we have defined for a given category,
@@ -25,7 +28,11 @@ func GetCategory(contents string, lang string, llm *ollama.LLM, ctx context.Cont
 		 */
 		return category, llmCategorized
 	} else {
-		category = LLMAssignCategory(contents, langCategory, llm, ctx, isDriverProject)
+		category, err = LLMAssignCategory(contents, langCategory, llm, ctx, isDriverProject)
+		if err != nil {
+			log.Printf("Error categorizing snippet with LLM: %v", err)
+			return "Uncategorized", true
+		}
 		if utils.SliceContainsString(validCategories, category) {
 			llmCategorized = true
 			return category, llmCategorized

--- a/audit/gdcd/add-code-examples/LLMAssignCategory.go
+++ b/audit/gdcd/add-code-examples/LLMAssignCategory.go
@@ -3,29 +3,37 @@ package add_code_examples
 import (
 	"common"
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/tmc/langchaingo/llms/ollama"
 )
 
-func LLMAssignCategory(contents string, langCategory string, llm *ollama.LLM, ctx context.Context, isDriverProject bool) string {
+func LLMAssignCategory(contents string, langCategory string, llm *ollama.LLM, ctx context.Context, isDriverProject bool) (string, error) {
 	var category string
+	var err error
+
 	if langCategory == JsonLike {
-		category = CategorizeJsonLikeSnippet(contents, llm, ctx)
+		category, err = CategorizeJsonLikeSnippet(contents, llm, ctx)
 	} else if langCategory == DriversMinusJs {
-		category = CategorizeDriverLanguageSnippet(contents, llm, ctx)
+		category, err = CategorizeDriverLanguageSnippet(contents, llm, ctx)
 	} else if langCategory == common.JavaScript || langCategory == common.Text {
 		if isDriverProject {
-			category = CategorizeDriverLanguageSnippet(contents, llm, ctx)
+			category, err = CategorizeDriverLanguageSnippet(contents, llm, ctx)
 		} else {
-			category = CategorizeTextSnippet(contents, llm, ctx)
+			category, err = CategorizeTextSnippet(contents, llm, ctx)
 		}
 	} else if langCategory == common.Shell {
-		category = CategorizeShellSnippet(contents, llm, ctx)
+		category, err = CategorizeShellSnippet(contents, llm, ctx)
 	} else if langCategory == common.Undefined {
-		category = CategorizeTextSnippet(contents, llm, ctx)
+		category, err = CategorizeTextSnippet(contents, llm, ctx)
 	} else {
 		log.Printf("Lang category is not one of the recognized ones - it's %s", langCategory)
+		return "", fmt.Errorf("unrecognized language category: %s", langCategory)
 	}
-	return category
+
+	if err != nil {
+		return "", fmt.Errorf("failed to categorize snippet: %w", err)
+	}
+	return category, nil
 }


### PR DESCRIPTION
Add error handling for the various categorization functions so the ingest tool continues to parse projects instead of a hard exit (`log.Fatalf()`)

example:
```text
2025/05/30 12:27:23 Found 1773 docs pages for project docs
2025/05/30 12:27:59 Error categorizing snippet with LLM: failed to categorize snippet: failed to generate a response from the CategorizeTextSnippet prompt (is Ollama running locally?): Post "http://127.0.0.1:11434/api/chat": dial tcp 127.0.0.1:11434: connect: connection refused
```
