### PR TITLE
(DOCSP-50509): GDCD: Make Atlas Architecture Center its own product

### DIFF
--- a/audit/dodec/README.md
+++ b/audit/dodec/README.md
@@ -42,6 +42,7 @@ Get IDs for pages based on various criteria:
 - [Rename a field](src/updates/RenameField.go) in the document across the 37 docs properties
 - [Rename a value](src/updates/RenameValue.go) in the document across the 37 docs properties
 - [Copy the current production DB for testing](/src/updates/CopyDBForTesting.go)
+- [Change the value of the `product` field](src/updates/ChangeProductName.go) (product name) in all docs within a collection
 
 **Print to console**
 

--- a/audit/dodec/src/updates/ChangeProductName.go
+++ b/audit/dodec/src/updates/ChangeProductName.go
@@ -1,0 +1,37 @@
+package updates
+
+import (
+	"context"
+	"fmt"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"log"
+)
+
+// ChangeProductName sets the `product` field value to a new value that you specify for all documents in the given collection.
+func ChangeProductName(db *mongo.Database, ctx context.Context) {
+	collection := db.Collection("atlas-architecture") // Set the collection where you need to update the product name
+	newProductName := "Atlas Architecture Center"     // Specify the new name for the product
+	// Omit the summary document, as the `$set` operator would add this field to the doc
+	filter := bson.M{
+		"_id": bson.M{
+			"$ne": "summaries",
+		},
+	}
+
+	// Define the update to set the Product field value
+	update := bson.M{
+		"$set": bson.M{
+			"product": newProductName,
+		},
+	}
+
+	// Perform the update
+	result, err := collection.UpdateMany(ctx, filter, update)
+	if err != nil {
+		log.Fatalf("Failed to update documents: %v", err)
+	}
+
+	// Print the result
+	fmt.Printf("Matched %d documents and modified %d documents\n", result.MatchedCount, result.ModifiedCount)
+}

--- a/audit/gdcd/GetProductSubProduct.go
+++ b/audit/gdcd/GetProductSubProduct.go
@@ -8,7 +8,7 @@ func GetProductSubProduct(project string, page string) (string, string) {
 	collectionProducts := map[string]string{
 		"atlas-cli":                "Atlas",
 		"atlas-operator":           "Atlas",
-		"atlas-architecture":       "Atlas",
+		"atlas-architecture":       "Atlas Architecture Center",
 		"bi-connector":             "BI Connector",
 		"c":                        "Drivers",
 		"charts":                   "Atlas",


### PR DESCRIPTION
Per this DOP PR, Atlas Architecture Center is now officially its own product in the taxonomy - it's not part of the Atlas product: https://github.com/mongodb/snooty-parser/pull/665

This PR updates the code so any new pages in the `atlas-architecture` project will be correctly tagged with the Atlas Architecture Center project in our code example database.

Separately, I'll need to update our existing data to change the product name for all of the documents in the `atlas-architecture` collection. I'm committing the update operation here along with the other change, as we'll need this again soon when we perform a similar update for the Django integration.