### PR TITLE
DOCSP-50530: Change product name for Django

### DIFF
--- a/audit/gdcd/GetProductSubProduct.go
+++ b/audit/gdcd/GetProductSubProduct.go
@@ -20,7 +20,7 @@ func GetProductSubProduct(project string, page string) (string, string) {
 		"cpp-driver":               "Drivers",
 		"csharp":                   "Drivers",
 		"database-tools":           "Database Tools",
-		"django":                   "Drivers",
+		"django":                   "Django Integration",
 		"docs":                     "Server",
 		"docs-k8s-operator":        "Enterprise Kubernetes Operator",
 		"docs-relational-migrator": "Relational Migrator",


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOCSP-50530

Per https://github.com/mongodb/snooty-parser/pull/665/files, Django is now its own product instead of part of the Drivers product. 