### PR TITLE
DODEC: Add aggregation to check for a specific substring in a page URL

### DIFF
--- a/audit/dodec/README.md
+++ b/audit/dodec/README.md
@@ -17,8 +17,8 @@ Get counts broken down in the following ways:
   - [By product](src/aggregations/GetProductLanguageCounts.go)
   - [By Atlas sub-product](src/aggregations/GetSubProductLanguageCounts.go)
   - [For a specific language by docs property](src/aggregations/GetSpecificLanguageCounts.go)
-  - [Manually get counts from the languages array on device versus using an aggregation](/src/aggregations/GetLangCountFromLangArrayManually.go)
-  - [From code nodes instead of the languages array (slower but used to diagnose data issues)](/src/aggregations/GetLangCountFromNodes.go)
+  - [Manually get counts from the languages array on device versus using an aggregation](src/aggregations/GetLangCountFromLangArrayManually.go)
+  - [From code nodes instead of the languages array (slower but used to diagnose data issues)](src/aggregations/GetLangCountFromNodes.go)
 - Category counts:
   - [By docs property](src/aggregations/GetCategoryCounts.go)
   - [By product](src/aggregations/GetProductCategoryCounts.go)
@@ -28,20 +28,24 @@ Get counts broken down in the following ways:
   - [One line usage examples by docs property](src/aggregations/GetOneLineUsageExampleCounts.go)
   - [Minimum, median, maximum character counts for code examples in the collection, and one-liner counts](src/aggregations/GetMinMedianMaxCodeLength.go)
 - Code example content counts:
-  - [Code examples containing a specific substring](src/aggregations/GetStringInCodeNodeCounts.go)
+  - [Code examples containing a specific
+    substring](src/aggregations/GetStringInCodeNodeCounts.go)
 
 Get IDs for pages based on various criteria:
-- [Find docs pages in Atlas that have had code examples added, updated, or removed within the last week](/src/aggregations/GetDocsIdsWithRecentActivity.go)
-- [Find docs pages in Atlas that have had new applied usage examples added within the last week](/src/aggregations/FindNewAppliedUsageExamples.go)
-- [Find docs pages in Atlas where the Product name is missing](/src/aggregations/FindDocsMissingProduct.go)
-- [Find docs pages in Atlas that have a count mismatch between the languages array and the languages in code nodes](/src/aggregations/GetPagesWithNodeLangCountMismatch.go)
+- [Find docs pages in Atlas that have had code examples added, updated, or removed within the last week](src/aggregations/GetDocsIdsWithRecentActivity.go)
+- [Find docs pages in Atlas that have had new applied usage examples added within the last week](src/aggregations/FindNewAppliedUsageExamples.go)
+- [Find docs pages in Atlas where the Product name is missing](src/aggregations/FindDocsMissingProduct.go)
+- [Find docs pages in Atlas that have a count mismatch between the languages array and the languages in code nodes](src/aggregations/GetPagesWithNodeLangCountMismatch.go)
+
+Get URLs for pages based on various criteria:
+- [Find page URLs in Atlas that contain a specific substring](src/aggregations/FindURLContainingString.go)
 
 **Update Documents**
 - [Add `product` and `sub_product` fields](src/updates/AddProductNames.go) to their relevant documents across the 37
   docs properties
 - [Rename a field](src/updates/RenameField.go) in the document across the 37 docs properties
 - [Rename a value](src/updates/RenameValue.go) in the document across the 37 docs properties
-- [Copy the current production DB for testing](/src/updates/CopyDBForTesting.go)
+- [Copy the current production DB for testing](src/updates/CopyDBForTesting.go)
 - [Change the value of the `product` field](src/updates/ChangeProductName.go) (product name) in all docs within a collection
 
 **Print to console**
@@ -62,13 +66,13 @@ tables.
   a docs property, and columns provide details about the minimum, median, and maximum character counts for code examples
   in the collection, as well as a count of "short" examples (under 80 characters) in the collection. Use with the
   [GetMinMedianMaxCodeLength](src/aggregations/GetMinMedianMaxCodeLength.go) aggregation.
-- [Print Page IDs with changes in the last week](/src/utils/PrintPageIdChangesCountMap.go) where each row represents a
+- [Print Page IDs with changes in the last week](src/utils/PrintPageIdChangesCountMap.go) where each row represents a
   page that has had changes, and each column lists the number of code examples added, updated, or removed on the page
-- [Print Page IDs with new applied usage examples in the last week](/src/utils/PrintPageIdNewAppliedUsageExampleCounts.go)
+- [Print Page IDs with new applied usage examples in the last week](src/utils/PrintPageIdNewAppliedUsageExampleCounts.go)
   where each row represents a page that has had new applied usage examples added (category is `common.UsageExample`
   and the `code` character count is greater than 300), and the counts column lists the number of code examples that meet
   this criteria. Prints a separate table for each collection, and an aggregate count at the end of the tables.
-- [Print page IDs with node language count mismatch](/src/utils/PrintPageIdChangesCountMap.go) with each table representing
+- [Print page IDs with node language count mismatch](src/utils/PrintPageIdChangesCountMap.go) with each table representing
   a different docs project, and each row is a Page ID for a document in that project that has a node/languages array
   count mismatch
 

--- a/audit/dodec/src/PerformAggregation.go
+++ b/audit/dodec/src/PerformAggregation.go
@@ -3,9 +3,7 @@ package main
 import (
 	"context"
 	"dodec/aggregations"
-	"dodec/types"
 	"dodec/utils"
-
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 )
@@ -19,12 +17,12 @@ func PerformAggregation(db *mongo.Database, ctx context.Context) {
 	//nestedOneLevelMap := make(map[string]map[string]int)
 	//nestedTwoLevelMap := make(map[string]map[string]map[string]int)
 	//pageIdChangesCountMap := make(map[string][]types.PageIdChangedCounts)
-	//pageIdsWithNodeLangCountMismatch := make(map[string][]string)
-	productSubProductCounter := types.NewAppliedUsageExampleCounterByProductSubProduct{
-		ProductSubProductCounts: make(map[string]map[string]int),
-		ProductAggregateCount:   make(map[string]int),
-		PagesInCollections:      make(map[string][]types.PageIdNewAppliedUsageExamples),
-	}
+	pageIdsWithNodeLangCountMismatch := make(map[string][]string)
+	//productSubProductCounter := types.NewAppliedUsageExampleCounterByProductSubProduct{
+	//	ProductSubProductCounts: make(map[string]map[string]int),
+	//	ProductAggregateCount:   make(map[string]int),
+	//	PagesInCollections:      make(map[string][]types.PageIdNewAppliedUsageExamples),
+	//}
 
 	// If you just need to get data for a single collection, perform the aggregation using the collection name
 	//simpleMap = aggregations.GetLanguageCounts(db, "pymongo", simpleMap, ctx)
@@ -36,6 +34,7 @@ func PerformAggregation(db *mongo.Database, ctx context.Context) {
 		panic(err)
 	}
 	//substringToFindInCodeExamples := "defaultauthdb"
+	substringToFindInPageURL := "code-examples"
 
 	for _, collectionName := range collectionNames {
 		//simpleMap = aggregations.GetCategoryCounts(db, collectionName, simpleMap, ctx)
@@ -56,7 +55,8 @@ func PerformAggregation(db *mongo.Database, ctx context.Context) {
 		//pageIdChangesCountMap = aggregations.GetDocsIdsWithRecentActivity(db, collectionName, pageIdChangesCountMap, ctx)
 		//pageIdsWithNodeLangCountMismatch = aggregations.GetPagesWithNodeLangCountMismatch(db, collectionName, pageIdsWithNodeLangCountMismatch, ctx)
 		//pageIdsWithNodeLangCountMismatch = aggregations.FindDocsMissingProduct(db, collectionName, pageIdsWithNodeLangCountMismatch, ctx)
-		productSubProductCounter = aggregations.FindNewAppliedUsageExamples(db, collectionName, productSubProductCounter, ctx)
+		//productSubProductCounter = aggregations.FindNewAppliedUsageExamples(db, collectionName, productSubProductCounter, ctx)
+		pageIdsWithNodeLangCountMismatch = aggregations.FindURLContainingString(db, collectionName, pageIdsWithNodeLangCountMismatch, ctx, substringToFindInPageURL)
 	}
 
 	//simpleTableLabel := "Collection"
@@ -77,6 +77,6 @@ func PerformAggregation(db *mongo.Database, ctx context.Context) {
 	// The length count map is a very specific fixed data structure, so this function has hard-coded title and column names/widths
 	//utils.PrintCodeLengthMapToConsole(codeLengthMap)
 	//utils.PrintPageIdChangesCountMap(pageIdChangesCountMap)
-	//utils.PrintPageIdsWithNodeLangCountMismatch(pageIdsWithNodeLangCountMismatch)
-	utils.PrintPageIdNewAppliedUsageExampleCounts(productSubProductCounter)
+	utils.PrintPageIdsWithNodeLangCountMismatch(pageIdsWithNodeLangCountMismatch)
+	//utils.PrintPageIdNewAppliedUsageExampleCounts(productSubProductCounter)
 }

--- a/audit/dodec/src/PerformAggregation.go
+++ b/audit/dodec/src/PerformAggregation.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"dodec/aggregations"
+	"dodec/types"
 	"dodec/utils"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -17,12 +18,12 @@ func PerformAggregation(db *mongo.Database, ctx context.Context) {
 	//nestedOneLevelMap := make(map[string]map[string]int)
 	//nestedTwoLevelMap := make(map[string]map[string]map[string]int)
 	//pageIdChangesCountMap := make(map[string][]types.PageIdChangedCounts)
-	pageIdsWithNodeLangCountMismatch := make(map[string][]string)
-	//productSubProductCounter := types.NewAppliedUsageExampleCounterByProductSubProduct{
-	//	ProductSubProductCounts: make(map[string]map[string]int),
-	//	ProductAggregateCount:   make(map[string]int),
-	//	PagesInCollections:      make(map[string][]types.PageIdNewAppliedUsageExamples),
-	//}
+	//pageIdsWithNodeLangCountMismatch := make(map[string][]string)
+	productSubProductCounter := types.NewAppliedUsageExampleCounterByProductSubProduct{
+		ProductSubProductCounts: make(map[string]map[string]int),
+		ProductAggregateCount:   make(map[string]int),
+		PagesInCollections:      make(map[string][]types.PageIdNewAppliedUsageExamples),
+	}
 
 	// If you just need to get data for a single collection, perform the aggregation using the collection name
 	//simpleMap = aggregations.GetLanguageCounts(db, "pymongo", simpleMap, ctx)
@@ -34,7 +35,7 @@ func PerformAggregation(db *mongo.Database, ctx context.Context) {
 		panic(err)
 	}
 	//substringToFindInCodeExamples := "defaultauthdb"
-	substringToFindInPageURL := "code-examples"
+	//substringToFindInPageURL := "code-examples"
 
 	for _, collectionName := range collectionNames {
 		//simpleMap = aggregations.GetCategoryCounts(db, collectionName, simpleMap, ctx)
@@ -55,8 +56,8 @@ func PerformAggregation(db *mongo.Database, ctx context.Context) {
 		//pageIdChangesCountMap = aggregations.GetDocsIdsWithRecentActivity(db, collectionName, pageIdChangesCountMap, ctx)
 		//pageIdsWithNodeLangCountMismatch = aggregations.GetPagesWithNodeLangCountMismatch(db, collectionName, pageIdsWithNodeLangCountMismatch, ctx)
 		//pageIdsWithNodeLangCountMismatch = aggregations.FindDocsMissingProduct(db, collectionName, pageIdsWithNodeLangCountMismatch, ctx)
-		//productSubProductCounter = aggregations.FindNewAppliedUsageExamples(db, collectionName, productSubProductCounter, ctx)
-		pageIdsWithNodeLangCountMismatch = aggregations.FindURLContainingString(db, collectionName, pageIdsWithNodeLangCountMismatch, ctx, substringToFindInPageURL)
+		productSubProductCounter = aggregations.FindNewAppliedUsageExamples(db, collectionName, productSubProductCounter, ctx)
+		//pageIdsWithNodeLangCountMismatch = aggregations.FindURLContainingString(db, collectionName, pageIdsWithNodeLangCountMismatch, ctx, substringToFindInPageURL)
 	}
 
 	//simpleTableLabel := "Collection"
@@ -77,6 +78,6 @@ func PerformAggregation(db *mongo.Database, ctx context.Context) {
 	// The length count map is a very specific fixed data structure, so this function has hard-coded title and column names/widths
 	//utils.PrintCodeLengthMapToConsole(codeLengthMap)
 	//utils.PrintPageIdChangesCountMap(pageIdChangesCountMap)
-	utils.PrintPageIdsWithNodeLangCountMismatch(pageIdsWithNodeLangCountMismatch)
-	//utils.PrintPageIdNewAppliedUsageExampleCounts(productSubProductCounter)
+	//utils.PrintPageIdsWithNodeLangCountMismatch(pageIdsWithNodeLangCountMismatch)
+	utils.PrintPageIdNewAppliedUsageExampleCounts(productSubProductCounter)
 }

--- a/audit/dodec/src/aggregations/FindDocsMissingProduct.go
+++ b/audit/dodec/src/aggregations/FindDocsMissingProduct.go
@@ -9,6 +9,9 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
+// FindDocsMissingProduct returns a list of all documentation page IDs in a given collection where the `product` field is
+// missing or contains an empty string. The string map key is the collection name, and the array of strings is an array
+// of page IDs that are missing a `product` value in the collection.
 func FindDocsMissingProduct(db *mongo.Database, collectionName string, pageIdsMissingProduct map[string][]string, ctx context.Context) map[string][]string {
 	var pageIds []string
 	collection := db.Collection(collectionName)

--- a/audit/dodec/src/aggregations/FindURLContainingString.go
+++ b/audit/dodec/src/aggregations/FindURLContainingString.go
@@ -1,0 +1,45 @@
+package aggregations
+
+import (
+	"context"
+	"fmt"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"log"
+)
+
+// FindURLContainingString returns the URL for the specified string present in any `page_url` within the collection.
+func FindURLContainingString(db *mongo.Database, collectionName string, pageURLMap map[string][]string, ctx context.Context, substring string) map[string][]string {
+	collection := db.Collection(collectionName)
+	fmt.Printf("Checking for substring '%s' in %s collection\n", substring, collectionName)
+	pipeline := mongo.Pipeline{
+		{{"$match", bson.D{
+			{"page_url", bson.D{
+				{"$regex", substring}, // Match documents containing the substring.
+				{"$options", "i"},     // Optionally make the search case-insensitive.
+			}},
+		}}},
+	}
+	cursor, err := collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		log.Fatalf("Failed to execute aggregation in collection %s: %v", collectionName, err)
+	}
+	defer cursor.Close(ctx)
+
+	if !cursor.Next(ctx) {
+		fmt.Println("Substring not found in any page URL in the collection")
+	}
+
+	// Iterate through the results
+	for cursor.Next(ctx) {
+		var result bson.M
+		if err := cursor.Decode(&result); err != nil {
+			log.Fatal(err)
+		}
+		// Append the URL to the array of matching URLs in the collection, and set the new array as the value for the collection
+		existingURLs := pageURLMap[collectionName]
+		existingURLs = append(existingURLs, result["page_url"].(string))
+		pageURLMap[collectionName] = existingURLs
+	}
+	return pageURLMap
+}

--- a/audit/dodec/src/aggregations/GetDocsIdsWithRecentActivity.go
+++ b/audit/dodec/src/aggregations/GetDocsIdsWithRecentActivity.go
@@ -10,6 +10,9 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
+// GetDocsIdsWithRecentActivity returns a slice of types.PageIdChangedCounts for the given collection. This aggregation
+// finds all docs pages with activity within the last week, and appends the page ID along with a count of each change type
+// to a list of pages with changes in the given collection. The string map key is the collection name.
 func GetDocsIdsWithRecentActivity(db *mongo.Database, collectionName string, aggregatePageIdCounts map[string][]types.PageIdChangedCounts, ctx context.Context) map[string][]types.PageIdChangedCounts {
 	// Calculate last week's date range
 	now := time.Now()

--- a/audit/dodec/src/aggregations/GetLangCountFromLangArrayManually.go
+++ b/audit/dodec/src/aggregations/GetLangCountFromLangArrayManually.go
@@ -9,6 +9,9 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
+// GetLangCountFromLangArrayManually processes the `Languages` field locally on device to get a count of all code examples
+// in each programming language within the collection. This function was used to debug discrepancies between the node language
+// count and the languages array count returned by other aggregations.
 func GetLangCountFromLangArrayManually(db *mongo.Database, collectionName string, languageCountMap map[string]int, ctx context.Context) map[string]int {
 	collection := db.Collection(collectionName)
 	// Define the aggregation pipeline

--- a/audit/dodec/src/aggregations/GetLangCountFromNodes.go
+++ b/audit/dodec/src/aggregations/GetLangCountFromNodes.go
@@ -8,6 +8,11 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
+// GetLangCountsFromNodes returns a count of code examples by programming language taken from the `nodes` array instead
+// of the `languages` array. The map string key is the programming language, and the int is the count of code examples
+// in that programming language, according to the elements in the `nodes` array. The count omits nodes that have been
+// removed from the page - i.e. where `is_removed` is `true`. This was cross-checked against the counts from the language
+// array in the GetLangCountFromLangArrayManually func.
 func GetLangCountsFromNodes(db *mongo.Database, collectionName string, languageCountMap map[string]int, ctx context.Context) map[string]int {
 	collection := db.Collection(collectionName)
 	languagePipeline := mongo.Pipeline{

--- a/audit/dodec/src/aggregations/GetPagesWithNodeLangCountMismatch.go
+++ b/audit/dodec/src/aggregations/GetPagesWithNodeLangCountMismatch.go
@@ -10,6 +10,10 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
+// GetPagesWithNodeLangCountMismatch is a function that compares the counts of code examples for each programming language
+// provided by the `languages` array versus a count from the `nodes` array. It returns a map whose string key is the
+// collection name. The slice value is a slice of page IDs where there is a mismatch between the programming language
+// counts from the `languages` array versus the counts from the `nodes` array.
 func GetPagesWithNodeLangCountMismatch(db *mongo.Database, collectionName string, pageIdsWithNodeLangCountMismatch map[string][]string, ctx context.Context) map[string][]string {
 	var pageIdsWithCountMismatch []string
 	collection := db.Collection(collectionName)


### PR DESCRIPTION
I needed to check for a substring in our URL structure, and we might want to do that again in future to find docs pages related to specific topics - i.e. in a given subdirectory - so I figured I would add the aggregation here.