### PR TITLE
DOCSP-50395: Add 'mcp-server' to product list

### DIFF
--- a/audit/gdcd/GetProductSubProduct.go
+++ b/audit/gdcd/GetProductSubProduct.go
@@ -4,7 +4,13 @@ import (
 	"strings"
 )
 
+// GetProductSubProduct returns the product taxonomy for a given page in a project, which corresponds to collection in Atlas.
+// It uses predefined mappings to determine the product and sub-product, if any, based on the project name and page URL.
 func GetProductSubProduct(project string, page string) (string, string) {
+
+	// Maps a project to a product name. Every project should have a corresponding product.
+	// Keys are the project names (in alpha order), and values are product names (from Docs taxonomy).
+	// This sets the `product` field for all documents in the project's collection in Atlas; otherwise, the field is left empty.
 	collectionProducts := map[string]string{
 		"atlas-cli":                "Atlas",
 		"atlas-operator":           "Atlas",
@@ -24,7 +30,7 @@ func GetProductSubProduct(project string, page string) (string, string) {
 		"docs":                     "Server",
 		"docs-k8s-operator":        "Enterprise Kubernetes Operator",
 		"docs-relational-migrator": "Relational Migrator",
-		"entity-framework":         "Drivers", // Missing from taxonomy/this is a guess
+		"entity-framework":         "Entity Framework Core Provider", // DOCSP-50997 to add to taxonomy
 		"golang":                   "Drivers",
 		"java":                     "Drivers",
 		"java-rs":                  "Drivers",
@@ -33,12 +39,13 @@ func GetProductSubProduct(project string, page string) (string, string) {
 		"kotlin-sync":              "Drivers",
 		"laravel":                  "Drivers",
 		"mck":                      "Enterprise Kubernetes Operator",
+		"mcp-server":               "MongoDB MCP Server", // DOCSP-50997 to add to taxonomy
 		"mongoid":                  "Drivers",
 		"mongodb-shell":            "MongoDB Shell",
 		"mongocli":                 "MongoDB CLI",
 		"node":                     "Drivers",
 		"ops-manager":              "Ops Manager",
-		"php-library":              "Drivers", // Missing from taxonomy/this is a guess
+		"php-library":              "Drivers", // DOCSP-51020 to add to taxonomy/programmatic tagging
 		"pymongo":                  "Drivers",
 		"pymongo-arrow":            "Drivers",
 		"ruby-driver":              "Drivers",
@@ -47,12 +54,18 @@ func GetProductSubProduct(project string, page string) (string, string) {
 		"spark-connector":          "Spark Connector",
 	}
 
+	// Maps a project to a sub-product, when applicable.
+	// Keys are the project names (in alpha order), and values are sub-product names (from Docs taxonomy).
+	// This sets the `sub_product` field for all documents in the project's collection in Atlas; otherwise, the field is omitted.
 	collectionSubProducts := map[string]string{
 		"atlas-cli":      "Atlas CLI",
 		"atlas-operator": "Kubernetes Operator",
 		"charts":         "Charts",
 	}
 
+	// Maps a subdirectory in the `cloud-docs` project to a sub-product, when applicable.
+	// Keys are the subdirectory names (in alpha order), and values are sub-product names (from Docs taxonomy).
+	// This sets the `sub_product` field for documents in the `cloud-docs` collection in Atlas whose page URL contains the subdirectory string; otherwise, the field is omitted.
 	atlasCollectionSubProductByDir := map[string]string{
 		"atlas-stream-processing": "Stream Processing",
 		"atlas-search":            "Search",


### PR DESCRIPTION
## Description

Update `GetProductSubProduct`: 
- Add `"mcp-server": "MongoDB MCP Server"` to product mapping
- Update `"entity-framework"` to map to `"Entity Framework Core Provider"`
- Add comments to explain the mappings 

Related Jira ticket: [DOCSP-50395](https://jira.mongodb.org/browse/DOCSP-50395)

## Tools Updated

Corresponding `README.md` also updated, if applicable
 
- [ ] audit/ask-cal 
- [ ] audit/dodec 
- [x] audit/gdcd
- [ ] audit/common
- [ ] examples-copier
- [ ] github-metrics 
- [ ] query-docs-feedback