### PR TITLE
(DOCSP-49924): GDCD: Back up DB before updating records

### DIFF
--- a/audit/gdcd/db/BackUpDB.go
+++ b/audit/gdcd/db/BackUpDB.go
@@ -1,0 +1,195 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func BackUpDb() {
+	uri := os.Getenv("MONGODB_URI")
+	docs := "www.mongodb.com/docs/drivers/go/current/"
+	if uri == "" {
+		log.Fatal("Set your 'MONGODB_URI' environment variable. " +
+			"See: " + docs +
+			"usage-examples/#environment-variable")
+	}
+
+	client, err := mongo.Connect(options.Client().
+		ApplyURI(uri))
+	var dbName = os.Getenv("DB_NAME")
+	var ctx = context.Background()
+	if err != nil {
+		log.Printf("Failed to connect to MongoDB: %v", err)
+	}
+	defer func() {
+		if err = client.Disconnect(ctx); err != nil {
+			log.Printf("Failed to disconnect from MongoDB: %v", err)
+		}
+	}()
+	// Define the database and collection
+	sourceDb := client.Database(dbName)
+
+	// Create a db name for today's backup
+	now := time.Now()
+	// Format the date as "Month_Day"
+	dateStr := fmt.Sprintf("%s_%d", now.Month(), now.Day())
+	targetDBName := "backup_code_metrics_" + dateStr
+	targetDb := client.Database(targetDBName)
+
+	// List all collections in the source database
+	collectionNames, err := sourceDb.ListCollectionNames(ctx, bson.D{})
+	if err != nil {
+		log.Fatalf("Error listing collections: %v", err)
+	}
+
+	log.Println("Backing up database...")
+	// Iterate over each collection
+	for _, collName := range collectionNames {
+		sourceColl := sourceDb.Collection(collName)
+		targetColl := targetDb.Collection(collName)
+		// Fetch all documents from the source collection
+		cursor, err := sourceColl.Find(ctx, bson.D{})
+		if err != nil {
+			log.Fatalf("Error finding documents in collection %s: %v", collName, err)
+		}
+		defer func(cursor *mongo.Cursor, ctx context.Context) {
+			err := cursor.Close(ctx)
+			if err != nil {
+				log.Fatalf("Error closing cursor: %v", err)
+			}
+		}(cursor, ctx)
+		var documents []interface{}
+		for cursor.Next(ctx) {
+			var doc bson.M
+			if err = cursor.Decode(&doc); err != nil {
+				log.Fatalf("Error decoding document in collection %s: %v", collName, err)
+			}
+			documents = append(documents, doc)
+		}
+		if len(documents) > 0 {
+			_, err = targetColl.InsertMany(ctx, documents)
+			if err != nil {
+				log.Fatalf("Error inserting documents into collection %s: %v", collName, err)
+			}
+			log.Printf("Copied %d documents to collection %s\n", len(documents), collName)
+		}
+	}
+	log.Println("Successfully backed up database")
+
+	// Drop the oldest backup. Get a list of backup names so we can find the oldest backup.
+	backupNames := getBackupDbNames(client, ctx)
+	oldestBackup := findOldestBackup(backupNames)
+	// Get a handle for the database
+	dbToDrop := client.Database(oldestBackup)
+
+	// Drop the database
+	err = dbToDrop.Drop(ctx)
+	if err != nil {
+		log.Fatalf("Failed to drop database %v: %v", oldestBackup, err)
+	}
+	log.Printf("Oldest backup database '%s' dropped successfully\n", oldestBackup)
+}
+
+// The cluster contains a mix of databases - some are backups, and some are other databases.
+// We want to get a slice of only the backup database names.
+func getBackupDbNames(client *mongo.Client, ctx context.Context) []string {
+	var backupNames []string
+	// List the database names in the cluster
+	databaseNames, err := client.ListDatabaseNames(ctx, bson.D{})
+	if err != nil {
+		log.Fatalf("Failed to list database names: %v", err)
+	}
+	// Get only the DB names for the backup databases
+	for _, databaseName := range databaseNames {
+		if strings.HasPrefix(databaseName, "backup_code_metrics") {
+			backupNames = append(backupNames, databaseName)
+		}
+	}
+	return backupNames
+}
+
+// Parse the dates from the backup database names to find the oldest backup database.
+func findOldestBackup(backupNames []string) string {
+	// Define a reference year (we need a year to work with Go's time package)
+	const year = 2025 // Arbitrary year for comparison purposes
+
+	// Variables to track the oldest date and its corresponding string
+	var oldestDate time.Time
+	var oldestBackupName string
+
+	// Iterate over the strings to extract and compare dates
+	for _, entry := range backupNames {
+		// Split the string and find the month and day (assume the format is fixed)
+		parts := strings.Split(entry, "_")
+		if len(parts) < 4 {
+			continue // Skip invalid strings
+		}
+		monthStr := parts[len(parts)-2] // Second-to-last part is the month
+		dayStr := parts[len(parts)-1]   // Last part is the day
+
+		// Convert the day string to an integer
+		day, err := strconv.Atoi(dayStr)
+		if err != nil {
+			fmt.Println("Error converting day:", err)
+			continue
+		}
+
+		// Parse the month using the time.Month enum
+		month, err := parseMonth(monthStr)
+		if err != nil {
+			fmt.Println("Error parsing month:", err)
+			continue
+		}
+
+		// Create a time.Time object for the given month and day
+		date := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+
+		// Compare dates to find the earliest one
+		if oldestBackupName == "" || date.Before(oldestDate) {
+			oldestDate = date
+			oldestBackupName = entry
+		}
+	}
+	return oldestBackupName
+}
+
+// Helper function to parse month names into time.Month
+func parseMonth(month string) (time.Month, error) {
+	month = strings.ToLower(month) // Make the string case-insensitive
+	switch month {
+	case "january":
+		return time.January, nil
+	case "february":
+		return time.February, nil
+	case "march":
+		return time.March, nil
+	case "april":
+		return time.April, nil
+	case "may":
+		return time.May, nil
+	case "june":
+		return time.June, nil
+	case "july":
+		return time.July, nil
+	case "august":
+		return time.August, nil
+	case "september":
+		return time.September, nil
+	case "october":
+		return time.October, nil
+	case "november":
+		return time.November, nil
+	case "december":
+		return time.December, nil
+	default:
+		return time.Month(0), fmt.Errorf("invalid month: %s", month)
+	}
+}

--- a/audit/gdcd/main.go
+++ b/audit/gdcd/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"gdcd/add-code-examples"
+	"gdcd/db"
 	"gdcd/snooty"
 	"gdcd/types"
 	"gdcd/utils"
@@ -89,6 +90,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to connect to ollama: %v", err)
 	}
+
+	// Backup the current database
+	db.BackUpDb()
 
 	// Process docs pages for every project in the projectsToParse array
 	firstProject := true


### PR DESCRIPTION
This PR adds backup functionality to GDCD. This backs up the current db to a db named `backup_code_metrics_Month_date`. After it has copied files to the backup DB, it finds and drops the oldest backup. 

Tested successfully in my dev environment with this output:

```
2025/06/24 22:40:09 Backing up database...
2025/06/24 22:40:09 Copied 25 documents to collection atlas-architecture
2025/06/24 22:40:13 Copied 1136 documents to collection cloud-docs
2025/06/24 22:40:14 Copied 88 documents to collection kotlin
2025/06/24 22:40:15 Copied 134 documents to collection docs-k8s-operator
2025/06/24 22:40:15 Copied 52 documents to collection atlas-operator
2025/06/24 22:40:15 Copied 10 documents to collection pymongo-arrow
2025/06/24 22:40:16 Copied 53 documents to collection mongodb-shell
2025/06/24 22:40:17 Copied 172 documents to collection docs-relational-migrator
2025/06/24 22:40:19 Copied 406 documents to collection mongocli
2025/06/24 22:40:20 Copied 92 documents to collection java
2025/06/24 22:40:22 Copied 498 documents to collection cloud-manager
2025/06/24 22:40:23 Copied 75 documents to collection golang
2025/06/24 22:40:24 Copied 109 documents to collection compass
2025/06/24 22:40:25 Copied 87 documents to collection pymongo
2025/06/24 22:40:25 Copied 59 documents to collection laravel
2025/06/24 22:40:25 Copied 28 documents to collection cloudgov
2025/06/24 22:40:26 Copied 75 documents to collection node
2025/06/24 22:40:26 Copied 24 documents to collection django
2025/06/24 22:40:28 Copied 256 documents to collection php-library
2025/06/24 22:40:28 Copied 56 documents to collection java-rs
2025/06/24 22:40:29 Copied 66 documents to collection cluster-sync
2025/06/24 22:40:30 Copied 133 documents to collection charts
2025/06/24 22:40:30 Copied 60 documents to collection database-tools
2025/06/24 22:40:31 Copied 71 documents to collection rust
2025/06/24 22:40:32 Copied 82 documents to collection csharp
2025/06/24 22:40:32 Copied 50 documents to collection c
2025/06/24 22:40:35 Copied 954 documents to collection atlas-cli
2025/06/24 22:40:35 Copied 56 documents to collection bi-connector
2025/06/24 22:40:38 Copied 615 documents to collection ops-manager
2025/06/24 22:40:38 Copied 18 documents to collection spark-connector
2025/06/24 22:40:39 Copied 54 documents to collection kotlin-sync
2025/06/24 22:40:39 Copied 66 documents to collection kafka-connector
2025/06/24 22:40:39 Copied 3 documents to collection test-data
2025/06/24 22:40:39 Copied 61 documents to collection mongoid
2025/06/24 22:40:44 Copied 1579 documents to collection docs
2025/06/24 22:40:45 Copied 14 documents to collection entity-framework
2025/06/24 22:40:45 Copied 49 documents to collection scala
2025/06/24 22:40:45 Copied 60 documents to collection cpp-driver
2025/06/24 22:40:45 Copied 42 documents to collection ruby-driver
2025/06/24 22:40:45 Successfully backed up database
2025/06/24 22:40:46 Oldest backup database 'backup_code_metrics_April_30' dropped successfully
```