### PR TITLE
(DOCSP-49695): Handle moved pages

### DIFF
--- a/audit/gdcd/CheckPagesForUpdates.go
+++ b/audit/gdcd/CheckPagesForUpdates.go
@@ -3,6 +3,7 @@ package main
 import (
 	"common"
 	"context"
+	"fmt"
 	"gdcd/db"
 	"gdcd/types"
 	"gdcd/utils"
@@ -17,8 +18,13 @@ import (
 func CheckPagesForUpdates(pages []types.PageWrapper, project types.ProjectDetails, llm *ollama.LLM, ctx context.Context, report types.ProjectReport) {
 	incomingPageIdsMatchingExistingPages := make(map[string]bool)
 	incomingDeletedPageCount := 0
-	var newPageIds []string
-	var newPages []common.DocsPage
+
+	// When a page doesn't match one in the DB, it could be either net new or a moved page. Hold it in a temp array
+	// for comparison
+	var maybeNewPages []types.NewOrMovedPage
+	var newPages []types.NewOrMovedPage
+	var newPageDBEntries []common.DocsPage
+	var movedPages []types.NewOrMovedPage
 	var updatedPages []common.DocsPage
 	for _, page := range pages {
 		// The Snooty Data API returns pages that may have been deleted. If the page is deleted, we want to check and see
@@ -40,19 +46,55 @@ func CheckPagesForUpdates(pages []types.PageWrapper, project types.ProjectDetail
 					updatedPages = append(updatedPages, *updatedPage)
 				}
 			} else {
-				// If there is no existing document in Atlas that matches the page, we need to make a new page
+				// If there is no existing document in Atlas that matches the page, we need to make a new page. BUT!
+				// It might actually be a new or moved page. So store it in a temp `maybeNewPages` slice so we can compare
+				// it against removed pages later and potentially call it a "moved" page, instead.
 				var newPage common.DocsPage
-				newPage, report = MakeNewPage(page, project.ProdUrl, report, llm, ctx)
-				newPageIds = append(newPageIds, newPage.ID)
-				newPages = append(newPages, newPage)
+				newPage = MakeNewPage(page, project.ProjectName, project.ProdUrl, llm, ctx)
+				newOrMovedPage := types.NewOrMovedPage{
+					PageId:              newPage.ID,
+					CodeNodeCount:       newPage.CodeNodesTotal,
+					LiteralIncludeCount: newPage.LiteralIncludesTotal,
+					IoCodeBlockCount:    newPage.IoCodeBlocksTotal,
+					PageData:            newPage,
+				}
+				maybeNewPages = append(maybeNewPages, newOrMovedPage)
 			}
 		}
 		utils.UpdateSecondaryTarget()
 	}
 
 	// After iterating through the incoming pages from the Snooty Data API, we need to figure out if any of the page IDs
-	// we had in the DB are not coming in from the incoming response. If so, we should delete those entries.
-	report = db.HandleMissingPageIds(project.ProjectName, incomingPageIdsMatchingExistingPages, report)
+	// we had in the DB are not coming in from the incoming response. If so, those pages are either moved or removed.
+	report, newPages, movedPages = db.HandleMissingPageIds(project.ProjectName, incomingPageIdsMatchingExistingPages, maybeNewPages, report)
+
+	// If we have new pages, increment the project report for them
+	if newPages != nil {
+		for _, page := range newPages {
+			newPageDBEntries = append(newPageDBEntries, page.PageData)
+			report = UpdateProjectReportForNewPage(page.PageData, report)
+		}
+	}
+
+	// If we have moved pages, handle them
+	if movedPages != nil {
+		for _, page := range movedPages {
+			// Remove the old page from the DB
+			db.RemovePageFromAtlas(project.ProjectName, page.OldPageId)
+
+			// Update the project counts for the "existing" page
+			report = IncrementProjectCountsForExistingPage(page.CodeNodeCount, page.LiteralIncludeCount, page.IoCodeBlockCount, page.PageData, report)
+
+			// Append the "moved" page to the `newPageDBEntries` array. Because the page ID doesn't match the old one,
+			// we write it to the DB as a new page. Because we just deleted the old page, it works out to the same count
+			// and provides the up-to-date data in the DB.
+			newPageDBEntries = append(newPageDBEntries, page.PageData)
+
+			// Report it in the logs as a moved page
+			stringMessageForReport := fmt.Sprintf("Old page ID: %s, new page ID: %s", page.OldPageId, page.NewPageId)
+			report = utils.ReportChanges(types.PageMoved, report, stringMessageForReport)
+		}
+	}
 
 	// Get the existing "summaries" document from the DB, and update it.
 	var summaryDoc common.CollectionReport
@@ -65,5 +107,5 @@ func CheckPagesForUpdates(pages []types.PageWrapper, project types.ProjectDetail
 	LogReportForProject(project.ProjectName, report)
 
 	// At this point, we have all the new and updated pages and an updated summary. Write updates to Atlas.
-	db.BatchUpdateCollection(project.ProjectName, newPages, updatedPages, summaryDoc)
+	db.BatchUpdateCollection(project.ProjectName, newPageDBEntries, updatedPages, summaryDoc)
 }

--- a/audit/gdcd/CheckPagesForUpdates.go
+++ b/audit/gdcd/CheckPagesForUpdates.go
@@ -84,7 +84,7 @@ func CheckPagesForUpdates(pages []types.PageWrapper, project types.ProjectDetail
 			newPageDBEntries = append(newPageDBEntries, newPage)
 
 			// Update the project counts for the "existing" page
-			report = IncrementProjectCountsForExistingPage(page.CodeNodeCount, page.LiteralIncludeCount, page.IoCodeBlockCount, newPage, report)
+			report = IncrementProjectCountsForExistingPage(newPage.CodeNodesTotal, newPage.LiteralIncludesTotal, newPage.IoCodeBlocksTotal, newPage, report)
 
 			// Report it in the logs as a moved page
 			stringMessageForReport := fmt.Sprintf("Old page ID: %s, new page ID: %s", page.OldPageId, page.NewPageId)

--- a/audit/gdcd/MakeNewPage.go
+++ b/audit/gdcd/MakeNewPage.go
@@ -3,7 +3,6 @@ package main
 import (
 	"common"
 	"context"
-	add_code_examples "gdcd/add-code-examples"
 	"gdcd/snooty"
 	"gdcd/types"
 	"gdcd/utils"
@@ -12,35 +11,29 @@ import (
 	"github.com/tmc/langchaingo/llms/ollama"
 )
 
-func MakeNewPage(data types.PageWrapper, siteUrl string, report types.ProjectReport, llm *ollama.LLM, ctx context.Context) (common.DocsPage, types.ProjectReport) {
+func MakeNewPage(data types.PageWrapper, projectName string, siteUrl string, llm *ollama.LLM, ctx context.Context) common.DocsPage {
 	incomingCodeNodes, incomingLiteralIncludeNodes, incomingIoCodeBlockNodes := snooty.GetCodeExamplesFromIncomingData(data.Data.AST)
 	incomingCodeNodeCount := len(incomingCodeNodes)
 	incomingLiteralIncludeNodeCount := len(incomingLiteralIncludeNodes)
 	incomingIoCodeNodeCount := len(incomingIoCodeBlockNodes)
 	pageId := utils.ConvertSnootyPageIdToAtlasPageId(data.Data.PageID)
 	pageUrl := utils.ConvertSnootyPageIdToProductionUrl(data.Data.PageID, siteUrl)
-	product, subProduct := GetProductSubProduct(report.ProjectName, pageUrl)
+	product, subProduct := GetProductSubProduct(projectName, pageUrl)
 	var isDriversProject bool
 	if product == "Drivers" {
 		isDriversProject = true
 	} else {
 		isDriversProject = false
 	}
-	newAppliedUsageExampleCount := 0
+
 	var newCodeNodes []common.CodeNode
 	for _, node := range incomingCodeNodes {
 		newNode := snooty.MakeCodeNodeFromSnootyAST(node, llm, ctx, isDriversProject)
 		newCodeNodes = append(newCodeNodes, newNode)
-		if add_code_examples.IsNewAppliedUsageExample(newNode) {
-			newAppliedUsageExampleCount++
-		}
 	}
 	maybeKeywords := snooty.GetMetaKeywords(data.Data.AST.Children)
 
 	languagesArrayValues := MakeLanguagesArray(newCodeNodes, incomingLiteralIncludeNodes, incomingIoCodeBlockNodes)
-
-	// Report relevant details for the new page
-	report = UpdateProjectReportForNewPage(incomingCodeNodeCount, incomingLiteralIncludeNodeCount, incomingIoCodeNodeCount, len(newCodeNodes), newAppliedUsageExampleCount, pageId, report)
 
 	return common.DocsPage{
 		ID:                   pageId,
@@ -52,9 +45,9 @@ func MakeNewPage(data types.PageWrapper, siteUrl string, report types.ProjectRep
 		LiteralIncludesTotal: incomingLiteralIncludeNodeCount,
 		Nodes:                &newCodeNodes,
 		PageURL:              pageUrl,
-		ProjectName:          report.ProjectName,
+		ProjectName:          projectName,
 		Product:              product,
 		SubProduct:           subProduct,
 		Keywords:             maybeKeywords,
-	}, report
+	}
 }

--- a/audit/gdcd/MakeNewPage.go
+++ b/audit/gdcd/MakeNewPage.go
@@ -11,13 +11,13 @@ import (
 	"github.com/tmc/langchaingo/llms/ollama"
 )
 
-func MakeNewPage(data types.PageWrapper, projectName string, siteUrl string, llm *ollama.LLM, ctx context.Context) common.DocsPage {
-	incomingCodeNodes, incomingLiteralIncludeNodes, incomingIoCodeBlockNodes := snooty.GetCodeExamplesFromIncomingData(data.Data.AST)
+func MakeNewPage(data types.PageMetadata, projectName string, siteUrl string, llm *ollama.LLM, ctx context.Context) common.DocsPage {
+	incomingCodeNodes, incomingLiteralIncludeNodes, incomingIoCodeBlockNodes := snooty.GetCodeExamplesFromIncomingData(data.AST)
 	incomingCodeNodeCount := len(incomingCodeNodes)
 	incomingLiteralIncludeNodeCount := len(incomingLiteralIncludeNodes)
 	incomingIoCodeNodeCount := len(incomingIoCodeBlockNodes)
-	pageId := utils.ConvertSnootyPageIdToAtlasPageId(data.Data.PageID)
-	pageUrl := utils.ConvertSnootyPageIdToProductionUrl(data.Data.PageID, siteUrl)
+	pageId := utils.ConvertSnootyPageIdToAtlasPageId(data.PageID)
+	pageUrl := utils.ConvertSnootyPageIdToProductionUrl(data.PageID, siteUrl)
 	product, subProduct := GetProductSubProduct(projectName, pageUrl)
 	var isDriversProject bool
 	if product == "Drivers" {
@@ -31,7 +31,7 @@ func MakeNewPage(data types.PageWrapper, projectName string, siteUrl string, llm
 		newNode := snooty.MakeCodeNodeFromSnootyAST(node, llm, ctx, isDriversProject)
 		newCodeNodes = append(newCodeNodes, newNode)
 	}
-	maybeKeywords := snooty.GetMetaKeywords(data.Data.AST.Children)
+	maybeKeywords := snooty.GetMetaKeywords(data.AST.Children)
 
 	languagesArrayValues := MakeLanguagesArray(newCodeNodes, incomingLiteralIncludeNodes, incomingIoCodeBlockNodes)
 

--- a/audit/gdcd/UpdateProjectReportForNewPage.go
+++ b/audit/gdcd/UpdateProjectReportForNewPage.go
@@ -1,29 +1,42 @@
 package main
 
 import (
+	"common"
+	"gdcd/add-code-examples"
 	"gdcd/types"
 	"gdcd/utils"
 )
 
-func UpdateProjectReportForNewPage(incomingCodeNodeCount int, incomingLiteralIncludeNodeCount int, incomingIoCodeBlockNodeCount int, newCodeNodes int, newAppliedUsageExampleCount int, pageId string, report types.ProjectReport) types.ProjectReport {
-	report.Counter.IncomingCodeNodesCount += incomingCodeNodeCount
-	report.Counter.IncomingLiteralIncludeCount += incomingLiteralIncludeNodeCount
-	report.Counter.IncomingIoCodeBlockCount += incomingIoCodeBlockNodeCount
-	report.Counter.NewCodeNodesCount += newCodeNodes
-	report.Counter.NewAppliedUsageExamplesCount += newAppliedUsageExampleCount
+func UpdateProjectReportForNewPage(page common.DocsPage, report types.ProjectReport) types.ProjectReport {
+	report.Counter.IncomingCodeNodesCount += page.CodeNodesTotal
+	report.Counter.IncomingLiteralIncludeCount += page.LiteralIncludesTotal
+	report.Counter.IncomingIoCodeBlockCount += page.IoCodeBlocksTotal
+	report.Counter.NewCodeNodesCount += page.CodeNodesTotal
 	report.Counter.NewPagesCount += 1
-	report = utils.ReportChanges(types.PageCreated, report, pageId)
-	if newCodeNodes > 0 {
-		report = utils.ReportChanges(types.CodeExampleCreated, report, pageId, newCodeNodes)
+	report = utils.ReportChanges(types.PageCreated, report, page.ID)
+	if page.CodeNodesTotal > 0 {
+		report = utils.ReportChanges(types.CodeExampleCreated, report, page.ID, page.CodeNodesTotal)
 	}
+
+	// Figure out how many of the page's code examples are new applied usage examples
+	newAppliedUsageExampleCount := 0
+	newCodeNodeCount := 0
+	if page.Nodes != nil {
+		for _, node := range *page.Nodes {
+			if add_code_examples.IsNewAppliedUsageExample(node) {
+				newAppliedUsageExampleCount++
+			}
+		}
+		newCodeNodeCount = len(*page.Nodes)
+	}
+	report.Counter.NewAppliedUsageExamplesCount += newAppliedUsageExampleCount
 
 	if newAppliedUsageExampleCount > 0 {
-		report = utils.ReportChanges(types.AppliedUsageExampleAdded, report, pageId, newAppliedUsageExampleCount)
+		report = utils.ReportChanges(types.AppliedUsageExampleAdded, report, page.ID, newAppliedUsageExampleCount)
 	}
 
-	newCodeNodeCount := newCodeNodes
-	if incomingCodeNodeCount != newCodeNodeCount {
-		report = utils.ReportIssues(types.CodeNodeCountIssue, report, pageId, incomingCodeNodeCount, newCodeNodeCount)
+	if page.CodeNodesTotal != newCodeNodeCount {
+		report = utils.ReportIssues(types.CodeNodeCountIssue, report, page.ID, page.CodeNodesTotal, newCodeNodeCount)
 	}
 	return report
 }

--- a/audit/gdcd/UpdateProjectReportForNewPage.go
+++ b/audit/gdcd/UpdateProjectReportForNewPage.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"common"
-	"gdcd/add-code-examples"
+	add_code_examples "gdcd/add-code-examples"
 	"gdcd/types"
 	"gdcd/utils"
 )
@@ -23,11 +23,13 @@ func UpdateProjectReportForNewPage(page common.DocsPage, report types.ProjectRep
 	newCodeNodeCount := 0
 	if page.Nodes != nil {
 		for _, node := range *page.Nodes {
-			if add_code_examples.IsNewAppliedUsageExample(node) {
-				newAppliedUsageExampleCount++
+			if !node.IsRemoved {
+				if add_code_examples.IsNewAppliedUsageExample(node) {
+					newAppliedUsageExampleCount++
+				}
+				newCodeNodeCount++
 			}
 		}
-		newCodeNodeCount = len(*page.Nodes)
 	}
 	report.Counter.NewAppliedUsageExamplesCount += newAppliedUsageExampleCount
 

--- a/audit/gdcd/UpdateProjectReportForNewPage.go
+++ b/audit/gdcd/UpdateProjectReportForNewPage.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"common"
-	add_code_examples "gdcd/add-code-examples"
+	"gdcd/add-code-examples"
 	"gdcd/types"
 	"gdcd/utils"
 )
@@ -23,12 +23,10 @@ func UpdateProjectReportForNewPage(page common.DocsPage, report types.ProjectRep
 	newCodeNodeCount := 0
 	if page.Nodes != nil {
 		for _, node := range *page.Nodes {
-			if !node.IsRemoved {
-				if add_code_examples.IsNewAppliedUsageExample(node) {
-					newAppliedUsageExampleCount++
-				}
-				newCodeNodeCount++
+			if add_code_examples.IsNewAppliedUsageExample(node) {
+				newAppliedUsageExampleCount++
 			}
+			newCodeNodeCount++
 		}
 	}
 	report.Counter.NewAppliedUsageExamplesCount += newAppliedUsageExampleCount

--- a/audit/gdcd/compare-code-examples/HandleRemovedCodeNodes.go
+++ b/audit/gdcd/compare-code-examples/HandleRemovedCodeNodes.go
@@ -14,7 +14,7 @@ func HandleRemovedCodeNodes(removedCodeNodes []common.CodeNode) []common.CodeNod
 	updatedRemovedNodes := make([]common.CodeNode, 0)
 	for _, node := range removedCodeNodes {
 		node.IsRemoved = true
-		node.DateUpdated = time.Now()
+		node.DateRemoved = time.Now()
 		updatedRemovedNodes = append(updatedRemovedNodes, node)
 	}
 	return updatedRemovedNodes

--- a/audit/gdcd/db/HandleMissingPageIds.go
+++ b/audit/gdcd/db/HandleMissingPageIds.go
@@ -5,28 +5,75 @@ import (
 	"gdcd/utils"
 )
 
-func HandleMissingPageIds(collectionName string, incomingPageIds map[string]bool, report types.ProjectReport) types.ProjectReport {
+// HandleMissingPageIds gets a list of all the page IDs from Atlas, compares each page ID against incoming ones coming
+// in from Snooty, and tries to figure out whether existing IDs that do not match incoming ones are moved pages or removed
+// pages. If the page is removed, we delete it from the DB. We pass moved and new pages back to the call site for further
+// handling.
+func HandleMissingPageIds(collectionName string, incomingPageIds map[string]bool, maybeNewPages []types.NewOrMovedPage, report types.ProjectReport) (types.ProjectReport, []types.NewOrMovedPage, []types.NewOrMovedPage) {
+	var movedPages []types.NewOrMovedPage
 	// Get a slice of all the page IDs for pages that are currently in Atlas
 	existingPageIds := GetAtlasPageIDs(collectionName)
 	// If we don't get any page IDs from Atlas, just return the unmodified report
 	if existingPageIds == nil {
-		return report
+		return report, maybeNewPages, movedPages
 	}
 	// Compare the pages that are currently in Atlas with pages coming in from the Snooty Data API. If the page exists
 	// in Atlas but isn't coming in from the Snooty Data API, grab the ID so we can remove the page in Atlas.
-	// TODO: There may be a logic issue here. When we could not retrieve the page ID from the DB; the page was getting
-	//  deleted. That suggests some logic is backward here, but I can't see a logic issue. Revisit if this still appears
-	//  to be a problem now that the DB retrieval func has retry logic. (And/or add testing for this!)
-	var pageIdsWithNoMatchingSnootyPage []string
+	var maybeRemovedPageIds []string
 	for _, existingId := range existingPageIds {
 		if incomingPageIds[existingId] {
 			// If the page ID in Atlas matches an incoming page ID from Snooty matches, skip the rest of the loop
 			continue
 		}
-		// If an existing ID in Atlas does not match any of the pages coming in from Snooty, add the ID to a list of pages we should delete
-		pageIdsWithNoMatchingSnootyPage = append(pageIdsWithNoMatchingSnootyPage, existingId)
+		// If an existing ID in Atlas does not match any of the pages coming in from Snooty, add the ID to a list of pages that might be removed
+		maybeRemovedPageIds = append(maybeRemovedPageIds, existingId)
 	}
-	for _, pageIdToDelete := range pageIdsWithNoMatchingSnootyPage {
+
+	var pageIdsToDelete []string
+
+	// A page ID that isn't an exact match for one coming in from Snooty could be either a moved page or a removed page
+	for _, maybeRemovedPageId := range maybeRemovedPageIds {
+		existingPage := GetAtlasPageData(collectionName, maybeRemovedPageId)
+		pageIsMoved := false
+
+		// Compare the removed page against the unaccounted for pages in the collection. An incoming page that
+		// does not have a matching page ID could be either moved or new. If the count of code examples, literalincludes,
+		// and io-code-blocks exactly matches a removed page, we'll call it "moved" instead of "new"
+		for index, maybeNewPage := range maybeNewPages {
+			// If the count of code examples is exactly the same, *and* that count is not 0, they might be the same page
+			codeNodeCountMatches := maybeNewPage.CodeNodeCount == existingPage.CodeNodesTotal && maybeNewPage.CodeNodeCount != 0
+
+			// To be more precise, also check if the count of literalincludes and io-code-blocks match
+			literalIncludeCountMatches := maybeNewPage.LiteralIncludeCount == existingPage.LiteralIncludesTotal
+			ioCodeBlockCountMatches := maybeNewPage.IoCodeBlockCount == existingPage.IoCodeBlocksTotal
+
+			// If all three counts match, and the code node count is not 0, consider it a moved page instead of new & removed pages
+			if codeNodeCountMatches && literalIncludeCountMatches && ioCodeBlockCountMatches {
+				maybeNewPage.NewPageId = maybeNewPage.PageId
+				maybeNewPage.OldPageId = existingPage.ID
+				maybeNewPage.PageData.DateAdded = existingPage.DateAdded
+				movedPages = append(movedPages, maybeNewPage)
+
+				// If we find a match, we can remove it from the `maybeNewPages` slice so we don't attempt to match it again
+				// Anything left in the `maybeNewPages` slice after comparing all the maybe removed pages is net new, so
+				// we'll pass it back to the call site to handle it as a new page
+				maybeNewPages = removeMovedPage(maybeNewPages, index)
+				pageIsMoved = true
+
+				// We've found a match, so we can skip the rest of the `maybeNewPages` for this `maybeRemovedPageId`
+				continue
+			}
+		}
+
+		// If we have gone through all the maybe new pages, and none is an exact match in code example counts, consider
+		// it a removed page
+		if !pageIsMoved {
+			pageIdsToDelete = append(pageIdsToDelete, maybeRemovedPageId)
+		}
+	}
+
+	// Handle all the removed pages
+	for _, pageIdToDelete := range pageIdsToDelete {
 		// We want to report details for the page we're about to delete, so we need to pull up the page to get the details
 		existingPage := GetAtlasPageData(collectionName, pageIdToDelete)
 		codeNodeCount := existingPage.CodeNodesTotal
@@ -50,5 +97,12 @@ func HandleMissingPageIds(collectionName string, incomingPageIds map[string]bool
 			report = utils.ReportIssues(types.PageNotRemovedIssue, report, pageIdToDelete)
 		}
 	}
-	return report
+
+	// Anything left in the `maybeNewPages` slice at this point is net new, so we'll handle it back at the call site
+	// Anything in the `movedPages` slice is moved, which we'll also handle back at the call site
+	return report, maybeNewPages, movedPages
+}
+
+func removeMovedPage(maybeNewPages []types.NewOrMovedPage, index int) []types.NewOrMovedPage {
+	return append(maybeNewPages[:index], maybeNewPages[index+1:]...)
 }

--- a/audit/gdcd/types/NewOrMovedPage.go
+++ b/audit/gdcd/types/NewOrMovedPage.go
@@ -1,13 +1,14 @@
 package types
 
-import "common"
+import "time"
 
 type NewOrMovedPage struct {
 	PageId              string
 	CodeNodeCount       int
 	LiteralIncludeCount int
 	IoCodeBlockCount    int
-	PageData            common.DocsPage
+	PageData            PageMetadata
 	OldPageId           string
 	NewPageId           string
+	DateAdded           time.Time
 }

--- a/audit/gdcd/types/NewOrMovedPage.go
+++ b/audit/gdcd/types/NewOrMovedPage.go
@@ -1,0 +1,13 @@
+package types
+
+import "common"
+
+type NewOrMovedPage struct {
+	PageId              string
+	CodeNodeCount       int
+	LiteralIncludeCount int
+	IoCodeBlockCount    int
+	PageData            common.DocsPage
+	OldPageId           string
+	NewPageId           string
+}

--- a/audit/gdcd/types/Report.go
+++ b/audit/gdcd/types/Report.go
@@ -25,6 +25,7 @@ const (
 	// Define the possible types of changes.
 	PageCreated ChangeType = iota
 	PageUpdated
+	PageMoved
 	PageRemoved
 	KeywordsUpdated
 	CodeExampleCreated
@@ -59,7 +60,7 @@ type Issue struct {
 
 // String returns a string representation of the ChangeType for easier readability.
 func (ct ChangeType) String() string {
-	return [...]string{"Page created", "Page updated", "Page removed", "Keywords updated", "Code example created", "Code example updated", "Code example removed", "Code node count change", "literalinclude count change", "io-code-block count change", "Project summary node count change", "Project summary page count change", "Applied usage example added"}[ct]
+	return [...]string{"Page created", "Page updated", "Page removed", "Page moved", "Keywords updated", "Code example created", "Code example updated", "Code example removed", "Code node count change", "literalinclude count change", "io-code-block count change", "Project summary node count change", "Project summary page count change", "Applied usage example added"}[ct]
 }
 
 // String returns a string representation of the IssueType for easier readability.

--- a/audit/gdcd/types/Report.go
+++ b/audit/gdcd/types/Report.go
@@ -60,7 +60,7 @@ type Issue struct {
 
 // String returns a string representation of the ChangeType for easier readability.
 func (ct ChangeType) String() string {
-	return [...]string{"Page created", "Page updated", "Page removed", "Page moved", "Keywords updated", "Code example created", "Code example updated", "Code example removed", "Code node count change", "literalinclude count change", "io-code-block count change", "Project summary node count change", "Project summary page count change", "Applied usage example added"}[ct]
+	return [...]string{"Page created", "Page updated", "Page moved", "Page removed", "Keywords updated", "Code example created", "Code example updated", "Code example removed", "Code node count change", "literalinclude count change", "io-code-block count change", "Project summary node count change", "Project summary page count change", "Applied usage example added"}[ct]
 }
 
 // String returns a string representation of the IssueType for easier readability.

--- a/audit/gdcd/utils/ReportChanges.go
+++ b/audit/gdcd/utils/ReportChanges.go
@@ -25,6 +25,8 @@ func ReportChanges(changeType types.ChangeType, report types.ProjectReport, stri
 		message = fmt.Sprintf("Page ID: %s", stringArg)
 	case types.PageUpdated:
 		message = fmt.Sprintf("Page ID: %s", stringArg)
+	case types.PageMoved:
+		message = fmt.Sprintf("%s", stringArg)
 	case types.PageRemoved:
 		message = fmt.Sprintf("Page ID: %s", stringArg)
 	case types.KeywordsUpdated:


### PR DESCRIPTION
There are two scenarios where the same code examples can show up as "new" and "removed" when they're really just moved:

- When a page is moved, the page ID doesn't match the old one, so we delete the old page and create a new page. Really, though, they're the same page.
- When a section of a page is moved out to a new page, some of the page content is split to a new ID. Code examples that are removed from the old page would be counted as "removed", and code examples on the newly-created page would be considered "new" - when they're really just the same examples.

After consideration, this PR only handles the first scenario - when a page is moved in its entirety. That should cover the majority of cases. Tracking moved partial content would potentially be a much bigger performance hit, because we would have to compare all "new" and all "removed" code examples in a docs set, versus tracking new and removed pages. The quantity of comparisons and comparison candidates would potentially be much higher.

For now, let's make this change and see what happens. We can consider attempting to track moved code examples as a future unit of work if we find we continue to see a lot of duplicated "new" and "removed" content.