### PR TITLE
DODEC: Update product names to match GDCD

### DIFF
--- a/audit/dodec/src/updates/AddProductNames.go
+++ b/audit/dodec/src/updates/AddProductNames.go
@@ -29,7 +29,7 @@ func AddProductNames(db *mongo.Database, ctx context.Context) {
 		"csharp":                "Drivers",
 		"database-tools":        "Database Tools",
 		"docs":                  "Server",
-		"docs-django":           "Drivers",
+		"docs-django":           "Django Integration",
 		"docs-entity-framework": "Drivers", // Missing from taxonomy/this is a guess
 		"docs-golang":           "Drivers",
 		"docs-java":             "Drivers",
@@ -39,6 +39,7 @@ func AddProductNames(db *mongo.Database, ctx context.Context) {
 		"kotlin":                "Drivers",
 		"kotlin-sync":           "Drivers",
 		"laravel":               "Drivers",
+		"mcp-server":            "MongoDB MCP Server",
 		"mck":                   "Enterprise Kubernetes Operator",
 		"mongoid":               "Drivers",
 		"mongodb-shell":         "MongoDB Shell",


### PR DESCRIPTION
We ingested `mcp-server` without adding the product name for it, so I had to add the product name using an update operation here in DODEC. And I noticed we maintain the set of product/sub-product names here, also.

We should refactor these out to the `common` package as a separate unit of work so we don't have to maintain these in two places. But for now, just committing these updates.