### PR TITLE
(DOCSP-49468): Parse code example category from incoming AST if present

### DIFF
--- a/audit/gdcd/add-code-examples/CategorizeJsonLikeSnippet_test.go
+++ b/audit/gdcd/add-code-examples/CategorizeJsonLikeSnippet_test.go
@@ -31,7 +31,7 @@ func TestCategorizeJsonLikeSnippet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CategorizeJsonLikeSnippet(tt.args.contents, tt.args.llm, tt.args.ctx); got != tt.want {
+			if got, _ := CategorizeJsonLikeSnippet(tt.args.contents, tt.args.llm, tt.args.ctx); got != tt.want {
 				t.Errorf("CategorizeJsonLikeSnippet() = got %v, want %v", got, tt.want)
 			}
 		})

--- a/audit/gdcd/add-code-examples/CategorizeShellSnippet_test.go
+++ b/audit/gdcd/add-code-examples/CategorizeShellSnippet_test.go
@@ -32,7 +32,7 @@ func TestCategorizeShellSnippet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CategorizeShellSnippet(tt.args.contents, tt.args.llm, tt.args.ctx); got != tt.want {
+			if got, _ := CategorizeShellSnippet(tt.args.contents, tt.args.llm, tt.args.ctx); got != tt.want {
 				t.Errorf("CategorizeShellSnippet() = got %v, want %v", got, tt.want)
 			}
 		})

--- a/audit/gdcd/add-code-examples/CategorizeTextSnippet_test.go
+++ b/audit/gdcd/add-code-examples/CategorizeTextSnippet_test.go
@@ -33,7 +33,7 @@ func TestCategorizeTextSnippet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CategorizeTextSnippet(tt.args.contents, tt.args.llm, tt.args.ctx); got != tt.want {
+			if got, _ := CategorizeTextSnippet(tt.args.contents, tt.args.llm, tt.args.ctx); got != tt.want {
 				t.Errorf("CategorizeTextSnippet() = got %v, want %v", got, tt.want)
 			}
 		})

--- a/audit/gdcd/add-code-examples/GetAstCodeNodeForCategoryForTesting.go
+++ b/audit/gdcd/add-code-examples/GetAstCodeNodeForCategoryForTesting.go
@@ -1,0 +1,23 @@
+package add_code_examples
+
+import "gdcd/types"
+
+func GetAstCodeNodeForCategoryForTesting(category string) types.ASTNode {
+	return types.ASTNode{
+		Type:           "code",
+		Position:       types.Position{Start: types.PositionLine{Line: 51}},
+		Children:       nil,
+		Value:          "SomeValue",
+		Lang:           "javascript",
+		Copyable:       false,
+		Entries:        nil,
+		EnumType:       "",
+		ID:             "",
+		Domain:         "",
+		Name:           "",
+		Argument:       nil,
+		Options:        nil,
+		EmphasizeLines: types.EmphasizeLines{14, 16},
+		Category:       category,
+	}
+}

--- a/audit/gdcd/add-code-examples/GetCategoryFromASTNode.go
+++ b/audit/gdcd/add-code-examples/GetCategoryFromASTNode.go
@@ -1,0 +1,36 @@
+package add_code_examples
+
+import (
+	"common"
+	"gdcd/types"
+	"log"
+	"strings"
+)
+
+func GetCategoryFromASTNode(node types.ASTNode) string {
+	if node.Category != "" {
+		return normalizeCategoryValue(node.Category)
+	} else {
+		return ""
+	}
+}
+
+func normalizeCategoryValue(category string) string {
+	lowercaseCategory := strings.ToLower(category)
+
+	switch {
+	case strings.Contains(lowercaseCategory, "syntax"):
+		return common.SyntaxExample
+	case strings.Contains(lowercaseCategory, "usage"):
+		return common.UsageExample
+	case strings.Contains(lowercaseCategory, "return"):
+		return common.ExampleReturnObject
+	case strings.Contains(lowercaseCategory, "configuration"):
+		return common.ExampleConfigurationObject
+	case strings.Contains(lowercaseCategory, "command"):
+		return common.NonMongoCommand
+	default:
+		log.Println("ISSUE: Handle the following non-normalizable category value: ", lowercaseCategory)
+		return ""
+	}
+}

--- a/audit/gdcd/add-code-examples/GetCategoryFromASTNode_test.go
+++ b/audit/gdcd/add-code-examples/GetCategoryFromASTNode_test.go
@@ -1,0 +1,48 @@
+package add_code_examples
+
+import (
+	"common"
+	"gdcd/types"
+	"testing"
+)
+
+func TestGetCategoryFromASTNode(t *testing.T) {
+	type args struct {
+		snootyNode types.ASTNode
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"syntax example", args{GetAstCodeNodeForCategoryForTesting("syntax example")}, common.SyntaxExample},
+		{"syntaxexample", args{GetAstCodeNodeForCategoryForTesting("syntaxexample")}, common.SyntaxExample},
+		{"syntax", args{GetAstCodeNodeForCategoryForTesting("syntax")}, common.SyntaxExample},
+		{"Syntax Example", args{GetAstCodeNodeForCategoryForTesting("Syntax Example")}, common.SyntaxExample},
+		{"usage example", args{GetAstCodeNodeForCategoryForTesting("usage example")}, common.UsageExample},
+		{"usageexample", args{GetAstCodeNodeForCategoryForTesting("usageexample")}, common.UsageExample},
+		{"usage", args{GetAstCodeNodeForCategoryForTesting("usage")}, common.UsageExample},
+		{"example return object", args{GetAstCodeNodeForCategoryForTesting("example return object")}, common.ExampleReturnObject},
+		{"return example", args{GetAstCodeNodeForCategoryForTesting("return example")}, common.ExampleReturnObject},
+		{"return object", args{GetAstCodeNodeForCategoryForTesting("return object")}, common.ExampleReturnObject},
+		{"example return", args{GetAstCodeNodeForCategoryForTesting("example return")}, common.ExampleReturnObject},
+		{"examplereturnobject", args{GetAstCodeNodeForCategoryForTesting("examplereturnobject")}, common.ExampleReturnObject},
+		{"return", args{GetAstCodeNodeForCategoryForTesting("return")}, common.ExampleReturnObject},
+		{"example configuration object", args{GetAstCodeNodeForCategoryForTesting("example configuration object")}, common.ExampleConfigurationObject},
+		{"configuration example", args{GetAstCodeNodeForCategoryForTesting("configuration example")}, common.ExampleConfigurationObject},
+		{"configuration object", args{GetAstCodeNodeForCategoryForTesting("configuration object")}, common.ExampleConfigurationObject},
+		{"example configuration", args{GetAstCodeNodeForCategoryForTesting("example configuration")}, common.ExampleConfigurationObject},
+		{"exampleconfigurationobject", args{GetAstCodeNodeForCategoryForTesting("exampleconfigurationobject")}, common.ExampleConfigurationObject},
+		{"configuration", args{GetAstCodeNodeForCategoryForTesting("configuration")}, common.ExampleConfigurationObject},
+		{"non mongodb command", args{GetAstCodeNodeForCategoryForTesting("non mongodb command")}, common.NonMongoCommand},
+		{"third party command", args{GetAstCodeNodeForCategoryForTesting("third party command")}, common.NonMongoCommand},
+		{"some other category", args{GetAstCodeNodeForCategoryForTesting("some other category")}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetCategoryFromASTNode(tt.args.snootyNode); got != tt.want {
+				t.Errorf("GetCategoryFromASTNode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/audit/gdcd/snooty/MakeCodeNodeFromSnootyAST.go
+++ b/audit/gdcd/snooty/MakeCodeNodeFromSnootyAST.go
@@ -12,11 +12,19 @@ import (
 )
 
 func MakeCodeNodeFromSnootyAST(snootyNode types.ASTNode, llm *ollama.LLM, ctx context.Context, isDriverProject bool) common.CodeNode {
+	var category string
+	var llmCategorized bool
 	whiteSpaceTrimmedCode := strings.TrimSpace(snootyNode.Value)
 	hashString := MakeSha256HashForCode(whiteSpaceTrimmedCode)
 	language := add_code_examples.GetNormalizedLanguageFromASTNode(snootyNode)
 	fileExtension := add_code_examples.GetFileExtensionFromASTNode(snootyNode)
-	category, llmCategorized := add_code_examples.GetCategory(whiteSpaceTrimmedCode, language, llm, ctx, isDriverProject)
+	maybeCategory := add_code_examples.GetCategoryFromASTNode(snootyNode)
+	if maybeCategory == "" {
+		category, llmCategorized = add_code_examples.GetCategory(whiteSpaceTrimmedCode, language, llm, ctx, isDriverProject)
+	} else {
+		category = maybeCategory
+		llmCategorized = false
+	}
 	return common.CodeNode{
 		Code:           whiteSpaceTrimmedCode,
 		Language:       language,

--- a/audit/gdcd/types/PageTypes.go
+++ b/audit/gdcd/types/PageTypes.go
@@ -54,6 +54,7 @@ type ASTNode struct {
 	Options        map[string]interface{} `json:"options,omitempty"`
 	EmphasizeLines EmphasizeLines         `json:"emphasize_lines,omitempty"`
 	LineNumbers    bool                   `json:"lineos,omitempty"`
+	Category       string                 `json:"category,omitempty"`
 }
 
 // ToctreeEntry details entries contained within a toctree.


### PR DESCRIPTION
This PR reads the value of the `category` option that may be provided on an ASTNode. If no category is present, we use the existing logic to assign a category.

(Also fixed some related tests that would no longer compile after a prior refactor.)

Jira ticket: https://jira.mongodb.org/browse/DOCSP-49468
