### PR TITLE
(DOCSP-51994): Update C2C to mongosync, move product/sub-product names out to `common`

### DIFF
--- a/audit/common/Constants.go
+++ b/audit/common/Constants.go
@@ -56,6 +56,47 @@ const (
 	ExampleReturnObject        = "Example return object"
 	ExampleConfigurationObject = "Example configuration object"
 	UsageExample               = "Usage example"
+
+	// Products
+
+	Atlas                        = "Atlas"
+	AtlasArchitecture            = "Atlas Architecture Center"
+	BIConnector                  = "BI Connector"
+	CloudManager                 = "Cloud Manager"
+	Compass                      = "Compass"
+	DBTools                      = "Database Tools"
+	Django                       = "Django Integration"
+	Drivers                      = "Drivers"
+	EnterpriseKubernetesOperator = "Enterprise Kubernetes Operator"
+	KafkaConnector               = "Kafka Connector"
+	MCPServer                    = "MongoDB MCP Server"
+	MDBCLI                       = "MongoDB CLI"
+	Mongosh                      = "MongoDB Shell"
+	Mongosync                    = "Mongosync"
+	OpsManager                   = "Ops Manager"
+	RelationalMigrator           = "Relational Migrator"
+	Server                       = "Server"
+	SparkConnector               = "Spark Connector"
+
+	// SubProducts
+
+	AtlasCLI         = "Atlas CLI"
+	AtlasOperator    = "Kubernetes Operator"
+	Charts           = "Charts"
+	DataFederation   = "Data Federation"
+	OnlineArchive    = "Online Archive"
+	Search           = "Search"
+	StreamProcessing = "Stream Processing"
+	Triggers         = "Triggers"
+	VectorSearch     = "Vector Search"
+
+	// Directories that map to specific sub-products
+	DataFederationDir   = "data-federation"
+	OnlineArchiveDir    = "online-archive"
+	SearchDir           = "atlas-search"
+	StreamProcessingDir = "atlas-stream-processing"
+	TriggersDir         = "triggers"
+	VectorSearchDir     = "atlas-vector-search"
 )
 
 var CanonicalLanguages = []string{Bash, C, CPP,

--- a/audit/common/GetProductInfo.go
+++ b/audit/common/GetProductInfo.go
@@ -1,0 +1,264 @@
+package common
+
+const (
+	CollectionIsProduct    = "collection"
+	CollectionIsSubProduct = "collectionIsSubProduct"
+	DirSubProduct          = "dirSubProduct"
+	FocusArea              = "focusArea"
+)
+
+type ProductInfo struct {
+	ProductName string
+	ProductType string
+	SubProduct  string
+}
+
+func GetProductInfo(projectOrSubdir string) ProductInfo {
+	if productInfo, found := productInfoMap[projectOrSubdir]; found {
+		return productInfo
+	}
+	// Return a default or zero-value struct if the key wasn't found
+	return ProductInfo{}
+}
+
+var SubProductDirs = []string{
+	DataFederationDir,
+	OnlineArchiveDir,
+	StreamProcessingDir,
+	SearchDir,
+	TriggersDir,
+	VectorSearchDir,
+}
+
+var productInfoMap = map[string]ProductInfo{
+	"atlas-cli": {
+		ProductName: Atlas,
+		ProductType: CollectionIsSubProduct,
+		SubProduct:  AtlasCLI,
+	},
+	"atlas-architecture": {
+		ProductName: AtlasArchitecture,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"atlas-operator": {
+		ProductName: Atlas,
+		ProductType: CollectionIsSubProduct,
+		SubProduct:  AtlasOperator,
+	},
+	"atlas-search": {
+		ProductName: Atlas,
+		ProductType: DirSubProduct,
+		SubProduct:  Search,
+	},
+	"atlas-stream-processing": {
+		ProductName: Atlas,
+		ProductType: DirSubProduct,
+		SubProduct:  StreamProcessing,
+	},
+	"atlas-vector-search": {
+		ProductName: Atlas,
+		ProductType: DirSubProduct,
+		SubProduct:  VectorSearch,
+	},
+	"bi-connector": {
+		ProductName: BIConnector,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"c": {
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"charts": {
+		ProductName: Atlas,
+		ProductType: CollectionIsSubProduct,
+		SubProduct:  Charts,
+	},
+	"cloud-docs": {
+		ProductName: Atlas,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"cloud-manager": {
+		ProductName: CloudManager,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"cloudgov": {
+		ProductName: Atlas,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"compass": {
+		ProductName: Compass,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"cpp-driver": {
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"csharp": {
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"database-tools": {
+		ProductName: DBTools,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"data-federation": {
+		ProductName: Atlas,
+		ProductType: DirSubProduct,
+		SubProduct:  DataFederation,
+	},
+	"django": {
+		ProductName: Django,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"docs": {
+		ProductName: Server,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"docs-k8s-operator": {
+		ProductName: Atlas,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"docs-relational-migrator": {
+		ProductName: RelationalMigrator,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"entity-framework": { // TODO: "Entity Framework Core Provider" DOCSP-50997 to add to taxonomy
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"golang": {
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"java": {
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"java-rs": {
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"kafka-connector": {
+		ProductName: KafkaConnector,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"kotlin": {
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"kotlin-sync": {
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"laravel": {
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"mck": {
+		ProductName: EnterpriseKubernetesOperator,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"mcp-server": { // DOCSP-50997 to add to taxonomy
+		ProductName: MCPServer,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"mongoid": {
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"mongodb-shell": {
+		ProductName: Mongosh,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"mongocli": {
+		ProductName: MDBCLI,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"mongosync": {
+		ProductName: Mongosync,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"node": {
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"online-archive": {
+		ProductName: Atlas,
+		ProductType: DirSubProduct,
+		SubProduct:  OnlineArchive,
+	},
+	"ops-manager": {
+		ProductName: OpsManager,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"php-library": { // DOCSP-51020 to add to taxonomy/programmatic tagging
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"pymongo": {
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"pymongo-arrow": {
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"ruby-driver": {
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"rust": {
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"scala": {
+		ProductName: Drivers,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"spark-connector": {
+		ProductName: SparkConnector,
+		ProductType: CollectionIsProduct,
+		SubProduct:  "",
+	},
+	"triggers": {
+		ProductName: Atlas,
+		ProductType: DirSubProduct,
+		SubProduct:  Triggers,
+	},
+}

--- a/audit/dodec/src/updates/AddProductNames.go
+++ b/audit/dodec/src/updates/AddProductNames.go
@@ -1,130 +1,100 @@
 package updates
 
 import (
+	"common"
 	"context"
 	"fmt"
-	"log"
-	"regexp"
-
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
+	"log"
+	"regexp"
 )
 
 // AddProductNames adds a human-readable `product` and `sub_product` (where applicable) fields to documents with values that correspond
 // to the Docs Taxonomy. If the document in the collection already has the applicable field(s), no change is made.
-// NOTE: Map uses the Snooty `project_name` (defined in the repo's `snooty.toml` file as `name`)
 func AddProductNames(db *mongo.Database, ctx context.Context) {
-	collectionProducts := map[string]string{
-		"atlas-cli":             "Atlas",
-		"atlas-operator":        "Atlas",
-		"bi-connector":          "BI Connector",
-		"c":                     "Drivers",
-		"charts":                "Atlas",
-		"cloud-docs":            "Atlas",
-		"cloud-manager":         "Cloud Manager",
-		"cloudgov":              "Atlas", // Missing from taxonomy/this is a guess
-		"cluster-sync":          "Cluster-to-Cluster sync",
-		"compass":               "Compass",
-		"cpp-driver":            "Drivers",
-		"csharp":                "Drivers",
-		"database-tools":        "Database Tools",
-		"docs":                  "Server",
-		"docs-django":           "Django Integration",
-		"docs-entity-framework": "Drivers", // Missing from taxonomy/this is a guess
-		"docs-golang":           "Drivers",
-		"docs-java":             "Drivers",
-		"docs-java-rs":          "Drivers",
-		"docs-k8s-operator":     "Enterprise Kubernetes Operator",
-		"kafka-connector":       "Kafka Connector",
-		"kotlin":                "Drivers",
-		"kotlin-sync":           "Drivers",
-		"laravel":               "Drivers",
-		"mcp-server":            "MongoDB MCP Server",
-		"mck":                   "Enterprise Kubernetes Operator",
-		"mongoid":               "Drivers",
-		"mongodb-shell":         "MongoDB Shell",
-		"mongocli":              "MongoDB CLI",
-		"node":                  "Drivers",
-		"ops-manager":           "Ops Manager",
-		"php-library":           "Drivers", // Missing from taxonomy/this is a guess
-		"pymongo":               "Drivers",
-		"pymongo-arrow":         "Drivers",
-		"relational-migrator":   "Relational Migrator",
-		"ruby-driver":           "Drivers",
-		"rust":                  "Drivers",
-		"scala":                 "Drivers",
-		"spark-connector":       "Spark Connector",
+	emptyFilter := bson.D{}
+	collectionNames, err := db.ListCollectionNames(ctx, emptyFilter)
+
+	if err != nil {
+		log.Fatal("Could not retrieve collection names from the database: ", err)
 	}
 
-	collectionSubProducts := map[string]string{
-		"atlas-cli":      "Atlas CLI",
-		"atlas-operator": "Kubernetes Operator",
-		"charts":         "Charts",
-	}
-
-	atlasCollectionSubProductByDir := map[string]string{
-		"atlas-stream-processing": "Stream Processing",
-		"atlas-search":            "Search",
-		"atlas-vector-search":     "Vector Search",
-		"data-federation":         "Data Federation",
-		"online-archive":          "Online Archive",
-		"triggers":                "Triggers",
-	}
-
-	for collectionName, productString := range collectionProducts {
+	for _, collectionName := range collectionNames {
 		collection := db.Collection(collectionName)
+		productInfo := common.GetProductInfo(collectionName)
+		var update bson.D
 
-		// Use UpdateMany to add the Product field
+		// Skip the "summaries" document because there should be no product or sub-product
 		filter := bson.D{{"_id", bson.D{{"$ne", "summaries"}}}}
-		update := bson.D{{"$set", bson.D{{"product", productString}}}}
+
+		switch productInfo.ProductType {
+		case common.CollectionIsProduct:
+			// If every document in the collection is a specific product with no sub-product (CollectionIsProduct),
+			// set the "product" field for every document
+			update = bson.D{{"$set", bson.D{{"product", productInfo.ProductName}}}}
+		case common.CollectionIsSubProduct:
+			// If every document in the collection is a sub-product, set both the product and sub-product field for
+			// every document in the collection
+			update = bson.D{
+				{"$set", bson.D{
+					{"product", productInfo.ProductName},
+					{"sub_product", productInfo.SubProduct},
+				}},
+			}
+		case common.DirSubProduct:
+			// Should not be able to hit this case because none of the collection names map to DirSubProduct strings
+			update = bson.D{}
+		default:
+			// If we hit this case, it's because we don't have a value matching the collection name, so we don't know
+			// what "product" key to assign and therefore we don't want to make an update
+			update = bson.D{}
+		}
+
 		updateResult, err := collection.UpdateMany(ctx, filter, update)
 		if err != nil {
 			log.Printf("Could not update documents to add a Product field in collection [%s]: %v", collectionName, err)
 			continue
 		}
 
-		fmt.Printf("Added a Product field to %d documents in the [%s] collection\n", updateResult.ModifiedCount, collectionName)
-	}
-
-	for collectionName, subProductString := range collectionSubProducts {
-		collection := db.Collection(collectionName)
-
-		// Define the filter to exclude documents with "_id" equal to "summaries"
-		filter := bson.D{{"_id", bson.D{{"$ne", "summaries"}}}}
-
-		// Define the update to add the "sub_product" field
-		update := bson.D{{"$set", bson.D{{"sub_product", subProductString}}}}
-
-		// Update all documents that match the filter
-		updateResult, err := collection.UpdateMany(ctx, filter, update)
-		if err != nil {
-			log.Printf("Could not update documents to add a sub-product field in collection [%s]: %v", collectionName, err)
-			continue
+		// Print a descriptive update depending on the type of operation we just completed
+		switch productInfo.ProductType {
+		case common.CollectionIsProduct:
+			fmt.Printf("Added a Product field '%s' to %d documents in the [%s] collection\n", productInfo.ProductName, updateResult.ModifiedCount, collectionName)
+		case common.CollectionIsSubProduct:
+			fmt.Printf("Added a Product field '%s' and Sub-Product field '%s' to %d documents in the [%s] collection\n", productInfo.ProductName, productInfo.SubProduct, updateResult.ModifiedCount, collectionName)
+		case common.DirSubProduct:
+			fmt.Printf("Added a Product field '%s' to %d documents in the [%s] collection\n", productInfo.ProductName, updateResult.ModifiedCount, collectionName)
+		default:
+			fmt.Printf("Could not retrieve a matching ProductInfo for [%s] collection, so no updates were made.\n", collectionName)
 		}
 
-		// Log the number of documents modified
-		fmt.Printf("Added a sub_product field to %d documents in the [%s] collection\n", updateResult.ModifiedCount, collectionName)
-	}
+		// In the Atlas (cloud) docs, some of the docs subdirectories correspond to specific sub-products. Add the relevant
+		// sub-product field to any page whose URL contains one of the relevant subdirectories
+		if collectionName == "cloud-docs" {
+			for _, dirPath := range common.SubProductDirs {
+				subProductInfo := common.GetProductInfo(dirPath)
 
-	for directorySubpath, subProductString := range atlasCollectionSubProductByDir {
-		// These are specifically all subdirectories in Cloud Docs, so hardcoding this here for convenience
-		collection := db.Collection("cloud-docs")
-		filter := bson.M{
-			"page_url": bson.M{
-				"$regex":   regexp.QuoteMeta(directorySubpath), // Properly escape special regex characters
-				"$options": "i",                                // Case-insensitive match
-			},
+				dirPathFilter := bson.M{
+					"page_url": bson.M{
+						"$regex":   regexp.QuoteMeta(dirPath), // Properly escape special regex characters
+						"$options": "i",                       // Case-insensitive match
+					},
+				}
+
+				// Define the update to add a new field with the desired value
+				dirSubProductUpdate := bson.M{
+					"$set": bson.M{"sub_product": subProductInfo.SubProduct},
+				}
+
+				// Apply the update to all matching documents
+				dirSubProductUpdateResult, err := collection.UpdateMany(ctx, dirPathFilter, dirSubProductUpdate)
+				if err != nil {
+					log.Printf("Could not update documents for path substring [%s]: %v", dirPath, err)
+					continue
+				}
+				fmt.Printf("Added a 'sub_product' field value '%s' to %d documents in 'cloud-docs' for path substring [%s]\n", subProductInfo.SubProduct, dirSubProductUpdateResult.ModifiedCount, dirPath)
+			}
 		}
-		// Define the update to add a new field with the desired value
-		update := bson.M{
-			"$set": bson.M{"sub_product": subProductString},
-		}
-		// Apply the update to all matching documents
-		updateResult, err := collection.UpdateMany(context.TODO(), filter, update)
-		if err != nil {
-			log.Printf("Could not update documents for substring [%s]: %v", directorySubpath, err)
-			continue
-		}
-		fmt.Printf("Added a sub_product field to %d documents in the collection for substring [%s]\n", updateResult.ModifiedCount, directorySubpath)
 	}
 }

--- a/audit/gdcd/GetProductSubProduct.go
+++ b/audit/gdcd/GetProductSubProduct.go
@@ -1,104 +1,29 @@
 package main
 
 import (
+	"common"
 	"strings"
 )
 
-/*
- * IMPORTANT: If you update mapped product values in this file, you must also run
- * the `changeProductName` function in DODEC to populate the new product values
- * to existing documents already in Atlas.
- */
-
-// GetProductSubProduct returns the product taxonomy for a given page in a project, which corresponds to collection in Atlas.
-// It uses predefined mappings to determine the product and sub-product, if any, based on the project name and page URL.
+// GetProductSubProduct returns the product taxonomy for a given page in a project, which corresponds to collection in our
+// code example database. It uses predefined mappings to determine the product and sub-product, if any, based on the
+// project name and page URL.
 func GetProductSubProduct(project string, page string) (string, string) {
+	var productInfo common.ProductInfo
 
-	// Maps a project to a product name. Every project should have a corresponding product.
-	// Keys are the project names (in alpha order), and values are product names (from Docs taxonomy).
-	// This sets the `product` field for all documents in the project's collection in Atlas; otherwise, the field is left empty.
-	collectionProducts := map[string]string{
-		"atlas-cli":                "Atlas",
-		"atlas-operator":           "Atlas",
-		"atlas-architecture":       "Atlas Architecture Center",
-		"bi-connector":             "BI Connector",
-		"c":                        "Drivers",
-		"charts":                   "Atlas",
-		"cloud-docs":               "Atlas",
-		"cloud-manager":            "Cloud Manager",
-		"cloudgov":                 "Atlas", // Missing from taxonomy/this is a guess
-		"cluster-sync":             "Cluster-to-Cluster sync",
-		"compass":                  "Compass",
-		"cpp-driver":               "Drivers",
-		"csharp":                   "Drivers",
-		"database-tools":           "Database Tools",
-		"django":                   "Django Integration",
-		"docs":                     "Server",
-		"docs-k8s-operator":        "Enterprise Kubernetes Operator",
-		"docs-relational-migrator": "Relational Migrator",
-		"entity-framework":         "Drivers", // TODO: "Entity Framework Core Provider" DOCSP-50997 to add to taxonomy
-		"golang":                   "Drivers",
-		"java":                     "Drivers",
-		"java-rs":                  "Drivers",
-		"kafka-connector":          "Kafka Connector",
-		"kotlin":                   "Drivers",
-		"kotlin-sync":              "Drivers",
-		"laravel":                  "Drivers",
-		"mck":                      "Enterprise Kubernetes Operator",
-		"mcp-server":               "MongoDB MCP Server", // DOCSP-50997 to add to taxonomy
-		"mongoid":                  "Drivers",
-		"mongodb-shell":            "MongoDB Shell",
-		"mongocli":                 "MongoDB CLI",
-		"node":                     "Drivers",
-		"ops-manager":              "Ops Manager",
-		"php-library":              "Drivers", // DOCSP-51020 to add to taxonomy/programmatic tagging
-		"pymongo":                  "Drivers",
-		"pymongo-arrow":            "Drivers",
-		"ruby-driver":              "Drivers",
-		"rust":                     "Drivers",
-		"scala":                    "Drivers",
-		"spark-connector":          "Spark Connector",
-	}
-
-	// Maps a project to a sub-product, when applicable.
-	// Keys are the project names (in alpha order), and values are sub-product names (from Docs taxonomy).
-	// This sets the `sub_product` field for all documents in the project's collection in Atlas; otherwise, the field is omitted.
-	collectionSubProducts := map[string]string{
-		"atlas-cli":      "Atlas CLI",
-		"atlas-operator": "Kubernetes Operator",
-		"charts":         "Charts",
-	}
-
-	// Maps a subdirectory in the `cloud-docs` project to a sub-product, when applicable.
-	// Keys are the subdirectory names (in alpha order), and values are sub-product names (from Docs taxonomy).
-	// This sets the `sub_product` field for documents in the `cloud-docs` collection in Atlas whose page URL contains the subdirectory string; otherwise, the field is omitted.
-	atlasCollectionSubProductByDir := map[string]string{
-		"atlas-stream-processing": "Stream Processing",
-		"atlas-search":            "Search",
-		"atlas-vector-search":     "Vector Search",
-		"data-federation":         "Data Federation",
-		"online-archive":          "Online Archive",
-		"triggers":                "Triggers",
-	}
-
-	product := collectionProducts[project]
-	subProduct := ""
-
+	// If the project is `cloud-docs`, the subdirectory of the docs may correspond with one of these strings. Each of
+	// them represents a different sub-product of Atlas. If the string is present in the page ID, return the corresponding
+	// product info.
 	if project == "cloud-docs" {
-		for directory, displayName := range atlasCollectionSubProductByDir {
-			if strings.Contains(page, directory) {
-				subProduct = displayName
+		subProductStringKeys := common.SubProductDirs
+		for _, dir := range subProductStringKeys {
+			if strings.Contains(page, dir) {
+				productInfo = common.GetProductInfo(dir)
 			}
 		}
 	} else {
-		// If it's a collection that directly correlates to one of the collectionSubProducts, it's an Atlas product
-		// and has the relevant sub-product display name
-		displayName, exists := collectionSubProducts[project]
-		if exists {
-			product = "Atlas"
-			subProduct = displayName
-			return product, subProduct
-		}
+		// Otherwise, just get the product/sub-product info defined in the common package
+		productInfo = common.GetProductInfo(project)
 	}
-	return product, subProduct
+	return productInfo.ProductName, productInfo.SubProduct
 }

--- a/audit/gdcd/snooty/GetProjects.go
+++ b/audit/gdcd/snooty/GetProjects.go
@@ -72,6 +72,7 @@ func GetProjects(client *http.Client) []types.ProjectDetails {
 		"atlas-app-services",
 		"drivers",
 		"mongoid-railsmdb",
+		"cluster-sync", // The Snooty Data API currently lists `cluster-sync` and `mongosync` as independent projects. We don't want to process twice, so ignore the `cluster-sync` entry.
 	}
 
 	var collectionsToParse []types.ProjectDetails


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-51994

While updating a product name for Cluster-to-Cluster Sync to Mongosync, I've refactored the product and sub-product names out to the `common` package so they are only maintained in one place. With these updates, I've:

- Added constants for the product, sub-product, and sub-product-directories
- Added a new `ProductInfo` type that contains the Product and Sub-Product values, if applicable, and also a `ProductType` field that we can use to drive the logic for how to apply them
- Created a `productInfo` map where the string key is the collection/project name, and the `ProductInfo` is populated for each collection/project

Then, I used the `GetProductInfo` func in both GDCD and DODEC to get the relevant info for a collection and/or page ID/page URL.

GDCD already had (minimal) tests to validate that I'm applying Product and Sub-Product correctly, and those tests still pass after this refactor. DODEC has no testing because YOLO 🙄 , so 🤞 it's all good there!