### PR TITLE
(DOCSP-51152): Add a `ChangeProjectName` func to rename a docs project

### DIFF
--- a/audit/dodec/src/updates/ChangeProjectName.go
+++ b/audit/dodec/src/updates/ChangeProjectName.go
@@ -1,0 +1,63 @@
+package updates
+
+import (
+	"context"
+	"fmt"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"log"
+)
+
+// ChangeProjectName sets the `project` field value to a new value that you specify for all documents in the given collection.
+// Then, it renames the collection.
+func ChangeProjectName(client *mongo.Client, dbName string, ctx context.Context) {
+
+	// ===== CONFIGURATION: Set these values before running =====
+	oldProjectName := "cluster-sync" // collection to update (this should match the old project name in `common`)
+	newProjectName := "mongosync"    // New project name to apply to the documents/rename the collection
+	// ==========================================================
+
+	codeMetricsDb := client.Database(dbName)
+	collection := codeMetricsDb.Collection(oldProjectName)
+
+	// Omit the summary document, as the `$set` operator would add this field to the doc
+	filter := bson.M{
+		"_id": bson.M{
+			"$ne": "summaries",
+		},
+	}
+
+	// Define the update to set the Project field value
+	update := bson.M{
+		"$set": bson.M{
+			"project_name": newProjectName,
+		},
+	}
+
+	// Perform the update
+	result, err := collection.UpdateMany(ctx, filter, update)
+	if err != nil {
+		log.Fatalf("Failed to update documents: %v", err)
+	}
+
+	// Print the result
+	fmt.Printf("Matched %d documents and modified %d documents\n", result.MatchedCount, result.ModifiedCount)
+
+	// Then, rename the collection. The Go Driver does not provide a method to do this directly, so using the runCommand method
+	// Form the BSON document to rename the collection
+	command := bson.D{
+		{"renameCollection", fmt.Sprintf("%s.%s", dbName, oldProjectName)},
+		{"to", fmt.Sprintf("%s.%s", dbName, newProjectName)},
+	}
+
+	// Execute the renameCollection command
+	adminDB := client.Database("admin") // The renameCollection command must be run on the admin database
+	renameResult := adminDB.RunCommand(ctx, command)
+
+	// Check for errors and handle the result
+	if err := renameResult.Err(); err != nil {
+		log.Fatal("Failed to rename collection:", err)
+	} else {
+		fmt.Printf("Collection renamed successfully from '%s' to '%s'\n", oldProjectName, newProjectName)
+	}
+}

--- a/audit/dodec/src/updates/ChangeProjectName.go
+++ b/audit/dodec/src/updates/ChangeProjectName.go
@@ -8,8 +8,8 @@ import (
 	"log"
 )
 
-// ChangeProjectName sets the `project` field value to a new value that you specify for all documents in the given collection.
-// Then, it renames the collection.
+// ChangeProjectName sets the `project_name` field value to a new value that you specify for all documents in the given
+// collection. Then, it renames the collection. This should match the project name defined in `common`
 func ChangeProjectName(client *mongo.Client, dbName string, ctx context.Context) {
 
 	// ===== CONFIGURATION: Set these values before running =====
@@ -27,7 +27,7 @@ func ChangeProjectName(client *mongo.Client, dbName string, ctx context.Context)
 		},
 	}
 
-	// Define the update to set the Project field value
+	// Define the update to set the ProjectName field value
 	update := bson.M{
 		"$set": bson.M{
 			"project_name": newProjectName,
@@ -43,8 +43,8 @@ func ChangeProjectName(client *mongo.Client, dbName string, ctx context.Context)
 	// Print the result
 	fmt.Printf("Matched %d documents and modified %d documents\n", result.MatchedCount, result.ModifiedCount)
 
-	// Then, rename the collection. The Go Driver does not provide a method to do this directly, so using the runCommand method
-	// Form the BSON document to rename the collection
+	// Then, rename the collection. The Go Driver does not provide a method to do this directly, so using the RunCommand method
+	// Form the BSON document to create the rename command
 	command := bson.D{
 		{"renameCollection", fmt.Sprintf("%s.%s", dbName, oldProjectName)},
 		{"to", fmt.Sprintf("%s.%s", dbName, newProjectName)},


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-51994

The `Cluster to Cluster Sync` _product_ was renamed, but the docs _project_ was also renamed. This PR adds an update func to DODEC to rename the project in the `project_name` field, and then to rename the collection, which we map directly to the project.

I have successfully used this to rename the `mongosync` project in my backup testing database, have made a backup of the prod db, and have renamed it in the prod db. So 🤞 everything should work as expected when we run GDCD today. Just adding this update func in case we rename more docs projects in the future.