### PR TITLE
Add a script to check product release versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # Code Example Tooling
 
-This repository contains tooling that the MongoDB Developer Docs team 
+This repository contains tooling that the MongoDB Developer Docs team
 uses to help us audit and track code examples across MongoDB's documentation
 corpus.
 
-- `github-metrics`: a Node.js script to get metrics from GitHub and write them
-  to a database in Atlas.
 - `audit`: Two Go projects, plus Go type definitions and constants that are
   common to both of them:
   - `gdcd`: The Great Docs Code Devourer gets code examples from MongoDB
@@ -13,8 +11,12 @@ corpus.
     writes the info to a database in Atlas.
   - `dodec`: The Database of Devoured Example Code: query and perform a few
     manual updates on the database of code examples and related metadata.
+- `examples-copier`: a Go app that runs as a GitHub App and copies files from the
+   source code repo (generated code examples) to multiple target repos and branches.
+- `github-check-releasese`: a Node.js script to get the latest release versions
+  of products we use in our test suites, and let us know what's outdated.
+- `github-metrics`: a Node.js script to get metrics from GitHub and write them
+  to a database in Atlas.
 - `query-docs-feedback`: A Go project and type definitions to query the MongoDB
   docs feedback for feedback related to code examples, and output the result
   to a report as .csv.
-- `examples-copier`: a Go app that runs as a GitHub App and copies files from the 
-   source code repo (generated code examples) to multiple target repos and branches.

--- a/github-check-releases/README.md
+++ b/github-check-releases/README.md
@@ -1,0 +1,105 @@
+# GitHub Check Releases
+
+This directory contains tooling to enable us to check GitHub releases programmatically, and validate them against the
+version(s) of the product(s) we use in our code example test suite(s).
+
+This is a simple PoC with two main components:
+
+- A [JSON file](repo-details.json) that contains the list of products, GitHub repo information, and test suite versions.
+- It uses [octokit](https://github.com/octokit/octokit.js) to get release data for those MongoDB products from GitHub, and compare it against the version 
+  in our JSON file.
+
+Future work may include automatically creating a Jira ticket to update the test suite when the version is out of date.
+
+## Add or change products and test suite versions
+
+This project pulls data from [repo-details.json](repo-details.json) to check the release versions for the MongoDB
+products we use in our code example test suites. It deserializes the data using `RepoDetails` declared in the
+[RepoDetails file](RepoDetails.js) to map the owner and repo name for a given product whose version we want to check.
+
+### Add a new product
+
+To add a new product, create a new entry for it in the `repo-details.json` file. 
+
+You can get the owner and name from the repo URL: `https://github.com/<owner>/<repo>`
+For example, to add `https://github.com/mongodb/node-mongodb-native`, set `mongodb` as the
+owner and `node-mongodb-native` as the repo name.
+
+You can get the test suite version from the test suite's dependency file. For example, the Node.js Driver version is in
+`code-example-tests/javascript/driver/package.json`, in the `dependencies` stanza:
+
+```
+"dependencies": {
+  "bluehawk": "^1.6.0",
+  "mongodb": "6.17.0" // This is the test suite version for the Driver
+}
+```
+
+The product name is just a human-readable name we can use in the output to report on the changes - i.e. `"Node.js Driver"`.
+
+### Change the test suite version
+
+If the version is out of date, bump the version in the test suite, and then update it in [repo-details.json](repo-details.json) here
+in this project.
+
+## GitHub release information
+
+### Get release information from GitHub
+
+This is a simple PoC that uses [octokit](https://github.com/octokit/octokit.js) to get release data for MongoDB products from GitHub.
+
+This code is in the `check-latest-releases.js` file.
+
+## Run the tool
+
+### Prerequisites
+
+To run the tool, you need:
+
+**GitHub**:
+
+- A [GitHub Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) (PAT) with `repo` permissions
+
+For this project, as a MongoDB org member, you must also auth your PAT with SSO.
+
+**System**:
+
+- Node.js/npm installed
+
+### Steps
+
+1. **Create a `.env` file**
+
+   Create a `.env` file that contains the following details:
+
+   ```
+   GITHUB_TOKEN="yourToken"
+   ```
+
+   Replace the placeholder value with your GitHub token.
+
+   > Note: The `.env` file is in the `.gitignore`, so no worries about accidentally committing credentials.
+
+2. **Install the dependencies**
+
+   From the root of the directory, run the following command to install project dependencies:
+
+   ```
+   npm install
+   ```
+
+3. **Run the utility**
+
+   From the root of the directory, run the following command to run the utility:
+
+   ```
+   node --env-file=.env index.js
+   ```
+
+   You should see output similar to:
+
+   ```
+   Warning: for C# Driver, test suite version v3.4.0 is behind latest release version v3.4.2
+   Warning: for Node.js Driver, test suite version v6.17.0 is behind latest release version v6.18.0
+   Test suite version for PyMongo Driver is up-to-date.
+   ```

--- a/github-check-releases/RepoDetails.js
+++ b/github-check-releases/RepoDetails.js
@@ -1,0 +1,8 @@
+export class RepoDetails {
+    constructor(owner, repo, productName, testSuiteVersion) {
+        this.owner = owner; // the GitHub organization or member who owns the repo
+        this.repo = repo; // the name of the repo within the organization or member
+        this.productName = productName;
+        this.testSuiteVersion = testSuiteVersion; // the version of the project currently used in the test suite
+    }
+}

--- a/github-check-releases/check-latest-releases.js
+++ b/github-check-releases/check-latest-releases.js
@@ -1,0 +1,16 @@
+async function checkLatestReleases(octokit, details) {
+    const latestRelease = await octokit.rest.repos.getLatestRelease({
+        owner: details.owner,
+        repo: details.repo
+    });
+    const tagName = latestRelease.data.tag_name;
+
+    if (tagName !== details.testSuiteVersion) {
+        console.log(`Warning: for ${details.productName}, test suite version ${details.testSuiteVersion} is behind latest release version ${tagName}`);
+        // TODO: Add code here to call a Jira endpoint to create a ticket to update the test suite. Store the Jira endpoint as a .env var to avoid exposing it in the public repo.
+    } else {
+        console.log(`Test suite version for ${details.productName} is up-to-date.`)
+    }
+}
+
+export { checkLatestReleases };

--- a/github-check-releases/package-lock.json
+++ b/github-check-releases/package-lock.json
@@ -1,0 +1,444 @@
+{
+  "name": "github-check-releases-tooling",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "github-check-releases-tooling",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "esm": "^3.2.25",
+        "octokit": "^5.0.3"
+      }
+    },
+    "node_modules/@octokit/app": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-16.0.1.tgz",
+      "integrity": "sha512-kgTeTsWmpUX+s3Fs4EK4w1K+jWCDB6ClxLSWUWTyhlw7+L3jHtuXDR4QtABu2GsmCMdk67xRhruiXotS3ay3Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-app": "^8.0.1",
+        "@octokit/auth-unauthenticated": "^7.0.1",
+        "@octokit/core": "^7.0.2",
+        "@octokit/oauth-app": "^8.0.1",
+        "@octokit/plugin-paginate-rest": "^13.0.0",
+        "@octokit/types": "^14.0.0",
+        "@octokit/webhooks": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-app": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-8.0.2.tgz",
+      "integrity": "sha512-dLTmmA9gUlqiAJZgozfOsZFfpN/OldH3xweb7lqSnngax5Rs+PfO5dDlokaBfc41H1xOtsLYV5QqR0DkBAtPmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^9.0.1",
+        "@octokit/auth-oauth-user": "^6.0.0",
+        "@octokit/request": "^10.0.2",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0",
+        "toad-cache": "^3.7.0",
+        "universal-github-app-jwt": "^2.2.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.1.tgz",
+      "integrity": "sha512-TthWzYxuHKLAbmxdFZwFlmwVyvynpyPmjwc+2/cI3cvbT7mHtsAW9b1LvQaNnAuWL+pFnqtxdmrU8QpF633i1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.1",
+        "@octokit/auth-oauth-user": "^6.0.0",
+        "@octokit/request": "^10.0.2",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.1.tgz",
+      "integrity": "sha512-TOqId/+am5yk9zor0RGibmlqn4V0h8vzjxlw/wYr3qzkQxl8aBPur384D1EyHtqvfz0syeXji4OUvKkHvxk/Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-methods": "^6.0.0",
+        "@octokit/request": "^10.0.2",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.0.tgz",
+      "integrity": "sha512-GV9IW134PHsLhtUad21WIeP9mlJ+QNpFd6V9vuPWmaiN25HEJeEQUcS4y5oRuqCm9iWDLtfIs+9K8uczBXKr6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.1",
+        "@octokit/oauth-methods": "^6.0.0",
+        "@octokit/request": "^10.0.2",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-unauthenticated": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-7.0.1.tgz",
+      "integrity": "sha512-qVq1vdjLLZdE8kH2vDycNNjuJRCD1q2oet1nA/GXWaYlpDxlR7rdVhX/K/oszXslXiQIiqrQf+rdhDlA99JdTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.3.tgz",
+      "integrity": "sha512-oNXsh2ywth5aowwIa7RKtawnkdH6LgU1ztfP9AIUCQCvzysB+WeU8o2kyyosDPwBZutPpjZDKPQGIzzrfTWweQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.1",
+        "@octokit/request": "^10.0.2",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.0.tgz",
+      "integrity": "sha512-hoYicJZaqISMAI3JfaDr1qMNi48OctWuOih1m80bkYow/ayPw6Jj52tqWJ6GEoFTk1gBqfanSoI1iY99Z5+ekQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.1.tgz",
+      "integrity": "sha512-j1nQNU1ZxNFx2ZtKmL4sMrs4egy5h65OMDmSbVyuCzjOcwsHq6EaYjOTGXPQxgfiN8dJ4CriYHk6zF050WEULg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.2",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-app": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-8.0.1.tgz",
+      "integrity": "sha512-QnhMYEQpnYbEPn9cae+wXL2LuPMFglmfeuDJXXsyxIXdoORwkLK8y0cHhd/5du9MbO/zdG/BXixzB7EEwU63eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^9.0.1",
+        "@octokit/auth-oauth-user": "^6.0.0",
+        "@octokit/auth-unauthenticated": "^7.0.1",
+        "@octokit/core": "^7.0.2",
+        "@octokit/oauth-authorization-url": "^8.0.0",
+        "@octokit/oauth-methods": "^6.0.0",
+        "@types/aws-lambda": "^8.10.83",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-authorization-url": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-8.0.0.tgz",
+      "integrity": "sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-methods": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-6.0.0.tgz",
+      "integrity": "sha512-Q8nFIagNLIZgM2odAraelMcDssapc+lF+y3OlcIPxyAU+knefO8KmozGqfnma1xegRDP4z5M73ABsamn72bOcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^8.0.0",
+        "@octokit/request": "^10.0.2",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/openapi-webhooks-types": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-12.0.3.tgz",
+      "integrity": "sha512-90MF5LVHjBedwoHyJsgmaFhEN1uzXyBDRLEBe7jlTYx/fEhPAk3P3DAJsfZwC54m8hAIryosJOL+UuZHB3K3yA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-graphql": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-6.0.0.tgz",
+      "integrity": "sha512-crfpnIoFiBtRkvPqOyLOsw12XsveYuY2ieP6uYDosoUegBJpSVxGwut9sxUgFFcll3VTOTqpUf8yGd8x1OmAkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-13.1.1.tgz",
+      "integrity": "sha512-q9iQGlZlxAVNRN2jDNskJW/Cafy7/XE52wjZ5TTvyhyOD904Cvx//DNyoO3J/MXJ0ve3rPoNWKEg5iZrisQSuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-16.0.0.tgz",
+      "integrity": "sha512-kJVUQk6/dx/gRNLWUnAWKFs1kVPn5O5CYZyssyEoNYaFedqZxsfYs7DwI3d67hGz4qOwaJ1dpm07hOAD1BXx6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.0.1.tgz",
+      "integrity": "sha512-KUoYR77BjF5O3zcwDQHRRZsUvJwepobeqiSSdCJ8lWt27FZExzb0GgVxrhhfuyF6z2B2zpO0hN5pteni1sqWiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=7"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.1.tgz",
+      "integrity": "sha512-S+EVhy52D/272L7up58dr3FNSMXWuNZolkL4zMJBNIfIxyZuUcczsQAU4b5w6dewJXnKYVgSHSV5wxitMSW1kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^7.0.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.3.tgz",
+      "integrity": "sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.0",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.0.tgz",
+      "integrity": "sha512-KRA7VTGdVyJlh0cP5Tf94hTiYVVqmt2f3I6mnimmaVz4UG3gQV/k4mDJlJv3X67iX6rmN7gSHCF8ssqeMnmhZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
+      }
+    },
+    "node_modules/@octokit/webhooks": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-14.1.1.tgz",
+      "integrity": "sha512-4kN/yPhcZEP+X7iMMuBTk+dD4ZGOpU57F7kHKrFlD2SSY/Sxh01t79oVn4npchLdPIXvLKrQw0uBXhmEaiZAdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-webhooks-types": "12.0.3",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/webhooks-methods": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/webhooks-methods": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-6.0.0.tgz",
+      "integrity": "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.152",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.152.tgz",
+      "integrity": "sha512-soT/c2gYBnT5ygwiHPmd9a1bftj462NWVk2tKCc1PYHSIacB2UwbTS2zYG4jzag1mRDuzg/OjtxQjQ2NKRB6Rw==",
+      "license": "MIT"
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "license": "MIT"
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/octokit": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/octokit/-/octokit-5.0.3.tgz",
+      "integrity": "sha512-+bwYsAIRmYv30NTmBysPIlgH23ekVDriB07oRxlPIAH5PI0yTMSxg5i5Xy0OetcnZw+nk/caD4szD7a9YZ3QyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/app": "^16.0.1",
+        "@octokit/core": "^7.0.2",
+        "@octokit/oauth-app": "^8.0.1",
+        "@octokit/plugin-paginate-graphql": "^6.0.0",
+        "@octokit/plugin-paginate-rest": "^13.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^16.0.0",
+        "@octokit/plugin-retry": "^8.0.1",
+        "@octokit/plugin-throttling": "^11.0.1",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0",
+        "@octokit/webhooks": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/universal-github-app-jwt": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
+      "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==",
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
+    }
+  }
+}

--- a/github-check-releases/package.json
+++ b/github-check-releases/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "github-check-releases-tooling",
+  "version": "1.0.0",
+  "description": "Utility to check the latest release for a set of given repo owners and names.",
+  "license": "ISC",
+  "author": "",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "esm": "^3.2.25",
+    "octokit": "^5.0.3"
+  }
+}

--- a/github-check-releases/repo-details.json
+++ b/github-check-releases/repo-details.json
@@ -1,0 +1,20 @@
+[
+  {
+    "owner": "mongodb",
+    "repo": "mongo-csharp-driver",
+    "productName": "C# Driver",
+    "testSuiteVersion": "v3.4.0"
+  },
+  {
+    "owner": "mongodb",
+    "repo": "node-mongodb-native",
+    "productName": "Node.js Driver",
+    "testSuiteVersion": "v6.17.0"
+  },
+  {
+    "owner": "mongodb",
+    "repo": "mongo-python-driver",
+    "productName": "PyMongo Driver",
+    "testSuiteVersion": "4.13.2"
+  }
+]


### PR DESCRIPTION
We should try to stay on top of product releases so we can version bump our test suites. This little script takes a mapping of versions that we use in our test suites, calls the GitHub endpoint to check the current release version, and outputs info to the console about things that are out of date.

We should be able to set up a Jira API endpoint to programmatically create tickets to bump the product versions, which we can triage and deal with as part of our regular workflow.