### PR TITLE
(DOCSP-52733): Improve Snooty Data API handling

### DIFF
--- a/audit/gdcd/snooty/GetProjectDocuments.go
+++ b/audit/gdcd/snooty/GetProjectDocuments.go
@@ -31,13 +31,13 @@ func GetProjectPages(project types.ProjectDetails, client *http.Client) []types.
 	} else {
 		resp, err := client.Get(apiURL)
 		if err != nil {
-			log.Fatalf("Failed to make request for project %s: %v", project.ProjectName, err)
+			log.Printf("ERROR: Failed to make request for project %s: %v", project.ProjectName, err)
 		}
 		defer resp.Body.Close()
 
 		// Check for HTTP error response
 		if resp.StatusCode != http.StatusOK {
-			log.Fatalf("Error: received status code %d for project %s", resp.StatusCode, project.ProjectName)
+			log.Printf("ERROR: received status code %d for project %s", resp.StatusCode, project.ProjectName)
 		}
 		log.Printf("\nSuccessfully retrieved a Snooty response for project %s. Deserializing to PageWrapper now.", project.ProjectName)
 		reader = *bufio.NewReader(resp.Body)

--- a/audit/gdcd/snooty/GetProjects.go
+++ b/audit/gdcd/snooty/GetProjects.go
@@ -39,23 +39,23 @@ func GetProjects(client *http.Client) []types.ProjectDetails {
 		apiURL := "https://snooty-data-api.mongodb.com/prod/projects/"
 		resp, err := client.Get(apiURL)
 		if err != nil {
-			log.Fatalf("Failed to make request: %v", err)
+			log.Fatalf("ERROR: Failed to get the projects list from the Snooty Data API: %v", err)
 		}
 		defer resp.Body.Close()
 
 		// Check for HTTP error response
 		if resp.StatusCode != http.StatusOK {
-			log.Fatalf("Error: received status code %d", resp.StatusCode)
+			log.Fatalf("ERROR: when requesting the projects list rom the Snooty Data API, received status code %d", resp.StatusCode)
 		}
 
 		// Read the response body
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			log.Fatalf("failed to read response body: %s", err)
+			log.Fatalf("ERROR: failed to read response body from Snooty Data API projects list: %s", err)
 		}
 		err = json.Unmarshal(body, &response)
 		if err != nil {
-			log.Fatalf("failed to unmarshal JSON: %s", err)
+			log.Fatalf("ERROR: failed to unmarshal JSON from the Snooty Data API projects list: %s", err)
 		}
 	}
 
@@ -92,12 +92,17 @@ func GetProjects(client *http.Client) []types.ProjectDetails {
 					break
 				}
 			}
-			collectionDetails := types.ProjectDetails{
-				ProjectName:  docsProject.Project,
-				ActiveBranch: activeBranch,
-				ProdUrl:      prodUrl,
+			// If the project does not have an active, stable branch, we don't want to try to get the project details
+			if activeBranch != "" {
+				collectionDetails := types.ProjectDetails{
+					ProjectName:  docsProject.Project,
+					ActiveBranch: activeBranch,
+					ProdUrl:      prodUrl,
+				}
+				collectionsToParse = append(collectionsToParse, collectionDetails)
+			} else {
+				log.Printf("Skipping project %s because it does not have an active, stable branch", docsProject.Project)
 			}
-			collectionsToParse = append(collectionsToParse, collectionDetails)
 		}
 	}
 	log.Println("Found ", len(collectionsToParse), "collections to parse from the Snooty Data API")

--- a/audit/gdcd/snooty/GetProjects.go
+++ b/audit/gdcd/snooty/GetProjects.go
@@ -45,7 +45,7 @@ func GetProjects(client *http.Client) []types.ProjectDetails {
 
 		// Check for HTTP error response
 		if resp.StatusCode != http.StatusOK {
-			log.Fatalf("ERROR: when requesting the projects list rom the Snooty Data API, received status code %d", resp.StatusCode)
+			log.Fatalf("ERROR: when requesting the projects list from the Snooty Data API, received status code %d", resp.StatusCode)
 		}
 
 		// Read the response body


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-52733

When fetching data from the Snooty Data API projects list endpoint (`GetProjects.go`):
- Errors should be fatal, because we can't proceed to fetching any specific project if we can't get the list of projects
- If a given project in the list does not have an active, stable branch, we should not attempt to fetch that specific project

When fetching a specific project (`GetProjectDocuments.go`):
- Errors should _not_ be fatal - we should log the error and continue on processing the rest of the projects. We can debug and individually fetch that project later.